### PR TITLE
Add a bunch of Australian news sites.

### DIFF
--- a/au.businessinsider.com.txt
+++ b/au.businessinsider.com.txt
@@ -1,0 +1,12 @@
+title://div[@class="sl-layout-post"]/h1
+body: //div[@id='content_post']
+strip: //div[contains(@class, "post-sidebar")]
+strip: //div[@id='related-links']
+strip: //img[@class='size_xlarge']
+author://div[@class="byline"]/a
+date://div[@class="byline"]/span[@class="date"]
+prune: no
+tidy: no
+
+
+test_url: http://www.businessinsider.com/microsoft-just-put-one-of-its-hardcore-technical-geniuses-on-xbox-2012-1

--- a/au.news.yahoo.com.txt
+++ b/au.news.yahoo.com.txt
@@ -1,0 +1,4 @@
+strip: //a[contains(text(), "RELATED:")]
+author: //div[@class="info"]//span[@class="association printer-source"]
+author: //div[@class="info"]//span[@class="stamp printer-date"]
+

--- a/brokernews.com.au.txt
+++ b/brokernews.com.au.txt
@@ -1,0 +1,2 @@
+author: //span[@itemprop="author"]
+date: //span[@itemprop="datePublished"]

--- a/choice.com.au.txt
+++ b/choice.com.au.txt
@@ -1,0 +1,4 @@
+
+body: //div[@id='content']//div[@id='mainBlogContentWrapper']//*[self::p or self::img or self::ul] | //div[@class='mainArticleIntro')]
+
+date: //span[@class='date']

--- a/cnet.com.au.txt
+++ b/cnet.com.au.txt
@@ -1,0 +1,17 @@
+title: //meta[@property="og:title"]/@content
+body: //div[contains(@class, 'postBody')]
+date: //div[@id='nameAndTime']/time
+author: //div[@id='nameAndTime']/span[@class='author']
+
+strip_id_or_class: image-credit
+strip_id_or_class: noAutolink
+strip_id_or_class: related
+strip_id_or_class: cite
+
+prune: no
+tidy: no
+
+# early end
+replace_string(Download today's podcast</a>): Download today's podcast</a></div></body></html>
+
+test_url: http://www.cnet.com/8301-13952_1-57367607-81/the-404-981-where-the-world-is-a-vampire-podcast/

--- a/dailytelegraph.com.au.txt
+++ b/dailytelegraph.com.au.txt
@@ -1,0 +1,5 @@
+title: //h1[@class="heading"]
+author: //cite[@class='author']
+date: //li[contains(@class, 'date-and-time')]
+
+

--- a/designbuildsource.com.au.txt
+++ b/designbuildsource.com.au.txt
@@ -1,0 +1,2 @@
+date: substring-after(//p[@class='post_date'], 'on')
+

--- a/gizmodo.com.au.txt
+++ b/gizmodo.com.au.txt
@@ -1,0 +1,8 @@
+body: //div[@id='content_post' or @class="post-body" or contains(@class, 'illustration top')]
+author: (//cite//span[@class="plus-icon"])[1]
+date: //span[@class="date"]
+date: //time
+
+prune: no
+
+test_url: http://gizmodo.com/5880147/kuhn-rikon-improves-their-spice-grinder-with-grade-school-science

--- a/heraldsun.com.au.txt
+++ b/heraldsun.com.au.txt
@@ -1,0 +1,12 @@
+#body: //div[@class='story-body']
+body: //div[contains(@class, 'story-body')]
+title: //div[@class='story-headline']//h1
+author: //cite[contains(@class, 'author')]
+date: //span[@class='datestamp']
+
+strip_id_or_class: story-info
+strip: //div[contains(@class, 'story-promo')]
+strip: //div[contains(@class, 'story-related')]
+
+prune: no
+tidy: no

--- a/itnews.com.au.txt
+++ b/itnews.com.au.txt
@@ -1,0 +1,5 @@
+title: //h1[@class='article-header']
+body: //div[@class='body-content']
+author: //span[@class='author-byline']/a[contains(@id, 'Author')]
+
+strip: //span[contains(@id, 'Article_SourceLabel')]

--- a/marketingmag.com.au.txt
+++ b/marketingmag.com.au.txt
@@ -1,0 +1,1 @@
+strip: //h3[@class="related-posts"]

--- a/moneymanagement.com.au.txt
+++ b/moneymanagement.com.au.txt
@@ -1,0 +1,2 @@
+date: //span[@class="publishdate"]//time
+author: //span[@class="byline"]

--- a/news.com.au.txt
+++ b/news.com.au.txt
@@ -1,0 +1,3 @@
+body: //div[@class='story-body']
+prune: no
+tidy: no

--- a/news.ninemsn.com.au.txt
+++ b/news.ninemsn.com.au.txt
@@ -1,0 +1,3 @@
+strip: //a[@class="contact"]
+strip: //div[@class="article-media video-item"]
+date: //div[@class='display-date']

--- a/perthnow.com.au.txt
+++ b/perthnow.com.au.txt
@@ -1,0 +1,12 @@
+#body: //div[@class='story-body']
+body: //div[contains(@class, 'story-body')]
+title: //div[@class='story-headline']//h1
+author: //cite[contains(@class, 'author')]
+date: //span[@class='datestamp']
+
+strip_id_or_class: story-info
+strip: //div[contains(@class, 'story-promo')]
+strip: //div[contains(@class, 'story-related')]
+
+prune: no
+tidy: no

--- a/smh.com.au.txt
+++ b/smh.com.au.txt
@@ -1,0 +1,14 @@
+body: //div[@id='content']
+title: //h1[@class='cN-headingPage']
+author: //h3[@class='authorName']
+date: //dd[@class='updated dtstamp']
+
+strip: //ul[@class='social sponsored cfix']
+strip: //div[contains(@class, 'hiddenVisually')]
+strip: //dd[@class='updated dtstamp']
+strip: //h3[@class='authorName']
+strip: //ul[@class='social  cfix']
+strip: //div[contains(@id, 'adspot')]
+
+strip: //div[contains(@class, 'overlayPlayCountdown')]
+strip: //div[@class='fdVideoWof']//span[@class='gone']

--- a/smh.drive.com.au.txt
+++ b/smh.drive.com.au.txt
@@ -1,0 +1,13 @@
+body: //div[@id='content']
+title: //h1[@class='cN-headingPage']
+author: //h3[@class='authorName']
+date: //dd[@class='updated dtstamp']
+
+strip: //ul[@class='social sponsored cfix']
+strip: //div[contains(@class, 'hiddenVisually')]
+strip: //dd[@class='updated dtstamp']
+strip: //h3[@class='authorName']
+strip: //ul[@class='social  cfix']
+strip: //div[contains(@id, 'adspot')]
+
+test_url: http://smh.drive.com.au/roads-and-traffic/driver-distraction-responsible-for-more-car-crashes-than-alcohol-20130503-2iyg0.html

--- a/sunshinecoastdaily.com.au.txt
+++ b/sunshinecoastdaily.com.au.txt
@@ -1,0 +1,10 @@
+body: //section//article//p
+
+strip: //aside
+strip: //div[@class='margin-top-15']
+strip: //p[@class='tags']
+
+author: //span[@class='byline']//ul[@class='piped']//li[1]
+date: //span[@class='byline']//ul[@class='piped']//li[2]
+
+parser: html5lib

--- a/theaustralian.com.au.txt
+++ b/theaustralian.com.au.txt
@@ -1,0 +1,6 @@
+body: //div[contains(@class, 'story-body')]
+author: //cite[contains(@class, 'author')]
+date: //span[@class='datestamp']
+
+strip: //div[@class='story-info']
+

--- a/watoday.com.au.txt
+++ b/watoday.com.au.txt
@@ -1,0 +1,7 @@
+author: //h3[@class="authorName"]
+date: //dd[@class='updated dtstamp']//time
+
+strip: //div[contains(@class, "adspot")]
+strip: //noscript
+strip: //p//small
+

--- a/weeklytimesnow.com.au.txt
+++ b/weeklytimesnow.com.au.txt
@@ -1,0 +1,4 @@
+body: //div[@class='main-col' or @class='article-image-wide']
+title: //h1[@class='article-title']
+author: substring-before(//span[@class='author'], "|")
+date: //span[@class='date']

--- a/westernadvocate.com.au.txt
+++ b/westernadvocate.com.au.txt
@@ -1,0 +1,11 @@
+title: //header[contains(@class, "news-article-title")]//h1
+date: //div[@class="news-article-byline"]//time
+author: //h2[@class="news-article-author"]//cite
+
+# Turns out that westernadvocate is doing funky things with the slide show images. :<
+# body: //ul[@class="slides"]//img | //div[contains(@class, "news-article-body")]
+body: //div[contains(@class, "news-article-body")]
+
+strip: //div[contains(@class, "flexslider")]
+
+test_url: http://:www.westernadvocate.com.au/story/1532050/roos-accept-ziebell-ban-commentators-do-not/


### PR DESCRIPTION
This pull request adds the following Australian news sites:

  * au.businessinsider.com
  * au.news.yahoo.com
  * brokernews.com.au
  * choice.com.au
  * cnet.com.au
  * dailytelegraph.com.au
  * designbuildsource.com.au
  * gizmodo.com.au
  * heraldsun.com.au
  * itnews.com.au
  * marketingmag.com.au
  * moneymanagement.com.au
  * news.com.au
  * news.ninemsn.com.au
  * perthnow.com.au
  * smh.com.au
  * smh.drive.com.au
  * sunshinecoastdaily.com.au
  * theaustralian.com.au
  * watoday.com.au
  * weeklytimesnow.com.au
  * westernadvocate.com.au