### PR TITLE
Get the real date content, not the enclosing div.

### DIFF
--- a/blogs.msdn.com.txt
+++ b/blogs.msdn.com.txt
@@ -1,6 +1,6 @@
 title: //h3[@class="post-name"]
 author: //span[@class="user-name"]
-date: //div[@class="post-date"]
+date: //div[@class="post-date"]/span[@class="value"]
 body: //div[@class="post-content user-defined-markup"]
 footnotes: no
 test_url: http://blogs.msdn.com/b/b8/archive/2011/10/04/designing-the-start-screen.aspx


### PR DESCRIPTION
The div contains useless text that prevents the date to be parsed correctly.

It also work on recent URLs like `http://blogs.msdn.com/b/typescript/archive/2015/03/05/angular-2-0-built-on-typescript.aspx`.