### PR TITLE
Networkworld.com

### DIFF
--- a/networkworld.com.txt
+++ b/networkworld.com.txt
@@ -2,6 +2,7 @@ author: //meta[@name="author"]/@content
 date: //meta[@name="DC.date.issued"]/@content
 
 body: //div[@itemprop="articleBody"]
+body: //div[@itemprop="reviewBody"]
 body: //figcaption|//div[@class="img-wrapper"]/noscript/img
 
 next_page_link: //a[@rel="next"]
@@ -19,3 +20,4 @@ test_url: http://www.networkworld.com/article/2951823/cisco-subnet/early-access-
 test_url: http://www.networkworld.com/article/2947478/mobile/what-if-the-apple-watch-really-is-a-flop.html
 test_url: http://www.networkworld.com/article/2953522/cloud-computing/nfv-a-hit-for-opendaylight.html
 test_url: http://www.networkworld.com/article/2960522/wi-fi/best-wi-fi-stumblers-for-the-mac.html
+test_url: http://www.networkworld.com/article/2969669/email-services/outlook-2016-review-a-new-coat-of-paint-on-the-same-reliable-personal-information-manager.html

--- a/networkworld.com.txt
+++ b/networkworld.com.txt
@@ -1,0 +1,16 @@
+author: //meta[@name="author"]/@content
+body: //div[@itemprop="articleBody"]
+next_page_link: //a[@rel="next"]
+
+strip: //aside
+strip: //h3[contains(., "See also:")]
+strip: //div[@id="article-top-page-number"]
+strip: //p[starts-with(normalize-space(.), '[')]
+strip: //p[starts-with(normalize-space(.), '+')]
+
+test_url: http://www.networkworld.com/index.rss 
+test_url: http://www.networkworld.com/article/2952852/email-services/4-great-gmail-tips-you-might-not-know-about.html#tk.rss_all
+test_url: http://www.networkworld.com/article/2951819/infrastructure-management/cios-say-applecare-for-enterprise-is-lacking.html
+test_url: http://www.networkworld.com/article/2951823/cisco-subnet/early-access-qa-new-cisco-ceo-chuck-robbins-heads-into-hyper-connected-mode.html
+test_url: http://www.networkworld.com/article/2947478/mobile/what-if-the-apple-watch-really-is-a-flop.html
+test_url: http://www.networkworld.com/article/2953522/cloud-computing/nfv-a-hit-for-opendaylight.html

--- a/networkworld.com.txt
+++ b/networkworld.com.txt
@@ -1,5 +1,9 @@
 author: //meta[@name="author"]/@content
+date: //meta[@name="DC.date.issued"]/@content
+
 body: //div[@itemprop="articleBody"]
+body: //figcaption|//div[@class="img-wrapper"]/noscript/img
+
 next_page_link: //a[@rel="next"]
 
 strip: //aside
@@ -14,3 +18,4 @@ test_url: http://www.networkworld.com/article/2951819/infrastructure-management/
 test_url: http://www.networkworld.com/article/2951823/cisco-subnet/early-access-qa-new-cisco-ceo-chuck-robbins-heads-into-hyper-connected-mode.html
 test_url: http://www.networkworld.com/article/2947478/mobile/what-if-the-apple-watch-really-is-a-flop.html
 test_url: http://www.networkworld.com/article/2953522/cloud-computing/nfv-a-hit-for-opendaylight.html
+test_url: http://www.networkworld.com/article/2960522/wi-fi/best-wi-fi-stumblers-for-the-mac.html


### PR DESCRIPTION
This config can also be used for other sites in the IDG network (eg. www.computerworld.com/s/article/9227679/Windows_8_Release_Preview_Updated_but_still_uneasy doesn't work with the existing configuration).

However I don't know what would be the correct way to signify this:
* symlinks? This will probably give problems on Windows
* Duplicate the file for all sites? If there's ever an update all versions will probably start to diverge
* Use fingerprints? I've tested locally using the following fingerprint: ```'Explore the IDG Network' => array('hostname'=>'networkworld.com', 'head'=>false)```