### PR TITLE
Add finexpert.e15.cz.txt

### DIFF
--- a/finexpert.e15.cz.txt
+++ b/finexpert.e15.cz.txt
@@ -1,0 +1,3 @@
+strip_id_or_class: article-linktoanother
+
+test_url: http://finexpert.e15.cz/budiz-teplo-eu-stedre-zadotuje-nejen-plynovy-kotel


### PR DESCRIPTION
Remove paragraph containing link/promo to different article. It is located inside main article body and sometimes gets picked (when it's longer?).