### PR TITLE
LWN.net: Fix author and date parsing for special articles

### DIFF
--- a/lwn.net.txt
+++ b/lwn.net.txt
@@ -13,6 +13,9 @@ title: //h1
 author: //div[@class='FeatureByline']/strong
 date: //div[@class='FeatureByline']/text()[preceding-sibling::br]
 strip: //div[@class='FeatureByline']
+author: substring-after(//div[@class='GAByline']/p[2], 'by ')
+date: //div[@class='GAByline']/p[1]
+strip: //div[@class='GAByline']
 
 # tidy will take care of fixing the tag mess that we make here.
 replace_string(<p class="Cat1HL">): <h1>
@@ -33,3 +36,4 @@ test_url: http://lwn.net/Articles/669114/
 test_url: http://lwn.net/Articles/670209/
 test_url: http://lwn.net/Articles/670209/rss
 test_url: http://lwn.net/Articles/668318/rss
+test_url: http://lwn.net/Articles/670062/


### PR DESCRIPTION
Hi,

I've added support for parsing meta data for a LWN.net article type that I've missed.

Cheers,

Lukas