### PR TITLE
Fix typo in facta.co.jp.txt

### DIFF
--- a/facta.co.jp.txt
+++ b/facta.co.jp.txt
@@ -1,3 +1,3 @@
-bosdy: //div[@class='content']
+body: //div[@class='content']
 
 test_url: http://facta.co.jp/blog/archives/20111026001026.html


### PR DESCRIPTION
The key name is "body", not "bosdy"