### PR TITLE
theguardian.com: Rewrite and fix author and date extraction.

### DIFF
--- a/theguardian.com.txt
+++ b/theguardian.com.txt
@@ -1,20 +1,29 @@
-title: //div[@id='main-article-info']//h1
-body: //figure[contains(@itemprop, "associatedMedia")] | //div[contains(@class, "content__article-body")]
-body: //figure[contains(@itemprop, "associatedMedia")] | //div[contains(@itemprop, "articleBody")]
-date: //li[@class='publication']//time[@pubdate] | //li[@class='publication']//data[@pubdate]
-strip: //div[contains(@class, 'email-subscription')]
-strip: //div[contains(@class, 'kindleWidget')]
-#strip: //a[not(text())]
-strip_id_or_class: pocket-btn
-author: //li[@class='byline']
-native_ad_clue: //meta[@property="article:tag" and contains(@content, "Partner zone")]
-native_ad_clue: //meta[@property="video:tag" and contains(@content, "Partner zone")]
+title: //h1[@itemprop='headline']
+
+body: //article
+strip: //article/header/div[contains(@class, 'content__header')]
+strip: //article/header/div[contains(@class, 'content__logo-container')]
+strip: //article//div[contains(@class, 'content__secondary-column')]
+strip: //article//aside
+strip: //article//div[contains(@class, 'block-share')]
+strip: //article//div[@class='submeta']
+strip: //article//span[contains(@class, 'inline-expand-image')]
+strip: //article//div[@class='kindleWidget']
+strip: //article//div[@class='email-subscription']
+strip: //article//script
+strip: //article//figure[contains(@class, 'element-audio')]
+strip: //article//a[contains(@style, 'display: none')]
+strip: //article/div[@class='paidfor-band']
+
+author: //article//p[@class='byline']
+date: //article//time/@datetime
+strip: //article//div[contains(@class, 'content__meta-container')]
+
+native_ad_clue: //meta[@property='article:tag' and contains(@content, 'partner zone')]
+native_ad_clue: //meta[@property='video:tag' and contains(@content, 'partner zone')]
+
 prune: no
 tidy: no
-
-parser: html5php
-
-strip_id_or_class: -expand-
 
 test_url: http://www.theguardian.com/world/2013/oct/04/nsa-gchq-attack-tor-network-encryption
 test_contains: The National Security Agency has made repeated attempts to develop
@@ -25,5 +34,8 @@ test_contains: In August, the editor of the Guardian rang me up and asked if I w
 test_contains: As the second most senior judge in the country, Lord Hoffmann, said in 2004 about a previous version of our anti-terrorism laws
 
 test_url: http://www.theguardian.com/commentisfree/2014/jun/15/britishness-search-identity-my-part-in-camerons-odyssey
+test_url: http://www.theguardian.com/world/2016/feb/17/ankara-explosion-turkey-injures-large-number-of-people-reports-say
+test_url: http://www.theguardian.com/uk-news/2016/feb/11/trident-the-british-question
+
 # Native ad
-test_url: http://www.theguardian.com/sustainable-business/2014/jul/18/ben-jerry-turn-ice-cream-into-energy
+test_url: http://www.theguardian.com/sustainable-business/fairtrade-partner-zone/chocolate-cocoa-production-risk


### PR DESCRIPTION
Hi,

I've rewritten the site config for theguardian.com. I think my solution produces good results and especially is able to extract the author and the date correctly.

I've also tested it with different kinds of articles.

Cheers,

Lukas