### PR TITLE
derStandard.at: Include images on the left in feed.

### DIFF
--- a/derstandard.at.txt
+++ b/derstandard.at.txt
@@ -1,12 +1,26 @@
 title: //div[@id='content-header']/h1
 author: //span[@class='author']
-body: //div[@class='copytext']
+body: //div[@id='objectContent']
 strip: //ul[@class='lookupLinksArtikel']
 
+strip: //meta
+strip: //div[@itemprop='publisher']
+strip: //div[@id='content-header']
 strip: //div[@id='pageTop']
 strip: //div[@id='toolbar']
 strip: //div[@id='articleTools']
 strip: //div[@id='weiterLesen']
 strip: //div[@id='communityCanvas']
+strip: //div[@class='credits']
+strip: //div[@id='feature-cover']
+strip: //div[@id='feature-meta']
+strip: //li[@class='empty']
+
+prune: no
+tidy: no
 
 test_url: http://derstandard.at/1318726018343/Breitband-LTE-Was-bringt-die-neue-Mobilfunk-Generation
+test_url: http://derstandard.at/2000033602592/40-Jahre-fuer-einen-der-nicht-gemeinsam-leben-wollte
+test_url: http://derstandard.at/2000017141382/Feature-Format
+test_url: http://derstandard.at/2000031826169/Die-Mittagspause-ist-den-meisten-heilig
+test_url: http://derstandard.at/2000032076109/Fordern-wir-die-totale-Ueberwachung


### PR DESCRIPTION
Hi,

I've updated the site config for derStandard.at a bit. The images on the left should also be included in the article and also additional information which is at the bottom of the article should be included in the content as well.

Cheers,

Lukas