### PR TITLE
add trailers.apple.com

### DIFF
--- a/trailers.apple.com.txt
+++ b/trailers.apple.com.txt
@@ -1,0 +1,9 @@
+# written by Jan Lukas Gernert
+
+title: //div[@id='hero']/h1
+author: //meta[@name='Author']/@content
+body: //section[@id='gallery-film-info-details']
+
+strip: //ul[@id='share']
+
+test_url: http://trailers.apple.com/trailers/independent/londonhasfallen/


### PR DESCRIPTION
It doesn't grab the actual trailer but all the metadata like short plot description, director, length, stars and so on.

Example:
![trailer apple com-demo](https://cloud.githubusercontent.com/assets/12012494/14436281/35560426-001c-11e6-9a94-a5ef7535cf32.jpg)
