### PR TITLE
add filmstarts.de

### DIFF
--- a/filmstarts.de.txt
+++ b/filmstarts.de.txt
@@ -1,0 +1,13 @@
+title: //div[@class='title large']
+author: //meta[@name='author']/@content
+
+body: //div[@id="col_main"]
+
+strip: //div[contains(@class, "samekind")]
+strip: //div[contains(@class, "shareThis")]
+strip: //div[@class="jtp"]
+strip: //div[@id="showdisqus"]
+strip: //div[@class="disqus_toggle"]
+strip: //div[@class="lighten margin_20b"]
+
+test_url: http://www.filmstarts.de/nachrichten/18503731.html

--- a/rss.filmstarts.de.txt
+++ b/rss.filmstarts.de.txt
@@ -1,0 +1,13 @@
+title: //div[@class='title large']
+author: //meta[@name='author']/@content
+
+body: //div[@id="col_main"]
+
+strip: //div[contains(@class, "samekind")]
+strip: //div[contains(@class, "shareThis")]
+strip: //div[@class="jtp"]
+strip: //div[@id="showdisqus"]
+strip: //div[@class="disqus_toggle"]
+strip: //div[@class="lighten margin_20b"]
+
+test_url: http://rss.filmstarts.de/~r/fs/news/filmnachrichten/~3/IItpQY2prWU/18503733.html


### PR DESCRIPTION
I am not sure if "filmstarts.de.txt" is needed.
The URL of the RSS-feed is "rss.filmstarts.de" that redirects to "filmstarts.de". But if you feed the content-grabber the direct URL to the article manually, the config file without "rss." could be useful. What do you think?