### PR TITLE
Fix pagination for JDG sites

### DIFF
--- a/jdubuzz.com.txt
+++ b/jdubuzz.com.txt
@@ -3,7 +3,7 @@
 # Source: http://siteconfig.fivefilters.org/grab.php?url=http://www.journaldugeek.com/2015/09/09/apple-ipad-pro/
 
 date: //meta[@property="og:updated_time"]/@content
-next_page_link: //div[contains(concat(' ',normalize-space(@class),' '),' pagination ')]/a[contains(concat(' ',normalize-space(@class),' '),' next ')]
+next_page_link: //div[@class="post-content"]/div[@class='row pagination']/a[contains(concat(' ',normalize-space(@class),' '),' next ')]
 
 strip_id_or_class: jdg-recommend
 strip_id_or_class: proofreader-bloc

--- a/jdubuzz.com.txt
+++ b/jdubuzz.com.txt
@@ -5,8 +5,9 @@
 date: //meta[@property="og:updated_time"]/@content
 next_page_link: //div[contains(concat(' ',normalize-space(@class),' '),' pagination ')]/a[contains(concat(' ',normalize-space(@class),' '),' next ')]
 
-strip: //div[contains(concat(' ',normalize-space(@class),' '),' jdg-recommend ')]
-strip: //div[contains(concat(' ',normalize-space(@class),' '),' proofreader-bloc ')]
+strip_id_or_class: jdg-recommend
+strip_id_or_class: proofreader-bloc
+strip_id_or_class: single-test
 
 body: //div[contains(concat(' ',normalize-space(@class),' '),' post-content ')]
 test_url: http://www.jdubuzz.com/2015/09/11/le-meilleur-du-jduzap-cest-maintenant/

--- a/journaldugamer.com.txt
+++ b/journaldugamer.com.txt
@@ -3,7 +3,7 @@
 # Source: http://siteconfig.fivefilters.org/grab.php?url=http://www.journaldugeek.com/2015/09/09/apple-ipad-pro/
 
 date: //meta[@property="og:updated_time"]/@content
-next_page_link: //div[contains(concat(' ',normalize-space(@class),' '),' pagination ')]/a[contains(concat(' ',normalize-space(@class),' '),' next ')]
+next_page_link: //div[@class="post-content"]/div[@class='row pagination']/a[contains(concat(' ',normalize-space(@class),' '),' next ')]
 
 strip_id_or_class: jdg-recommend
 strip_id_or_class: proofreader-bloc

--- a/journaldugamer.com.txt
+++ b/journaldugamer.com.txt
@@ -5,8 +5,9 @@
 date: //meta[@property="og:updated_time"]/@content
 next_page_link: //div[contains(concat(' ',normalize-space(@class),' '),' pagination ')]/a[contains(concat(' ',normalize-space(@class),' '),' next ')]
 
-strip: //div[contains(concat(' ',normalize-space(@class),' '),' jdg-recommend ')]
-strip: //div[contains(concat(' ',normalize-space(@class),' '),' proofreader-bloc ')]
+strip_id_or_class: jdg-recommend
+strip_id_or_class: proofreader-bloc
+strip_id_or_class: single-test
 
 body: //div[contains(concat(' ',normalize-space(@class),' '),' post-content ')]
 test_url: http://www.journaldugamer.com/2015/09/14/financier-desormais-tete-nintendo/

--- a/journaldugeek.com.txt
+++ b/journaldugeek.com.txt
@@ -3,7 +3,7 @@
 # Source: http://siteconfig.fivefilters.org/grab.php?url=http://www.journaldugeek.com/2015/09/09/apple-ipad-pro/
 
 date: //meta[@property="og:updated_time"]/@content
-next_page_link: //div[contains(concat(' ',normalize-space(@class),' '),' pagination ')]/a[contains(concat(' ',normalize-space(@class),' '),' next ')]
+next_page_link: //div[@class="post-content"]/div[@class='row pagination']/a[contains(concat(' ',normalize-space(@class),' '),' next ')]
 
 strip_id_or_class: jdg-recommend
 strip_id_or_class: proofreader-bloc

--- a/journaldugeek.com.txt
+++ b/journaldugeek.com.txt
@@ -5,8 +5,9 @@
 date: //meta[@property="og:updated_time"]/@content
 next_page_link: //div[contains(concat(' ',normalize-space(@class),' '),' pagination ')]/a[contains(concat(' ',normalize-space(@class),' '),' next ')]
 
-strip: //div[contains(concat(' ',normalize-space(@class),' '),' jdg-recommend ')]
-strip: //div[contains(concat(' ',normalize-space(@class),' '),' proofreader-bloc ')]
+strip_id_or_class: jdg-recommend
+strip_id_or_class: proofreader-bloc
+strip_id_or_class: single-test
 
 body: //div[contains(concat(' ',normalize-space(@class),' '),' post-content ')]
 test_url: http://www.journaldugeek.com/2015/09/09/apple-ipad-pro/

--- a/news.pixelistes.com.txt
+++ b/news.pixelistes.com.txt
@@ -3,7 +3,7 @@
 # Source: http://siteconfig.fivefilters.org/grab.php?url=http://www.journaldugeek.com/2015/09/09/apple-ipad-pro/
 
 date: //meta[@property="og:updated_time"]/@content
-next_page_link: //div[contains(concat(' ',normalize-space(@class),' '),' pagination ')]/a[contains(concat(' ',normalize-space(@class),' '),' next ')]
+next_page_link: //div[@class="post-content"]/div[@class='row pagination']/a[contains(concat(' ',normalize-space(@class),' '),' next ')]
 
 strip_id_or_class: jdg-recommend
 strip_id_or_class: proofreader-bloc

--- a/news.pixelistes.com.txt
+++ b/news.pixelistes.com.txt
@@ -5,8 +5,9 @@
 date: //meta[@property="og:updated_time"]/@content
 next_page_link: //div[contains(concat(' ',normalize-space(@class),' '),' pagination ')]/a[contains(concat(' ',normalize-space(@class),' '),' next ')]
 
-strip: //div[contains(concat(' ',normalize-space(@class),' '),' jdg-recommend ')]
-strip: //div[contains(concat(' ',normalize-space(@class),' '),' proofreader-bloc ')]
+strip_id_or_class: jdg-recommend
+strip_id_or_class: proofreader-bloc
+strip_id_or_class: single-test
 
 body: //div[contains(concat(' ',normalize-space(@class),' '),' post-content ')]
 test_url: http://news.pixelistes.com/pixelistes-partenaire-du-salon-de-la-photo-de-paris/


### PR DESCRIPTION
All pages have a ' next ' link to view the next content, not the next page.
But contents with more than one page also got this link but it's not embedded in `single-test` class node.
So we first remove that block and we found the ' next ' content, it means it's multipage article.