### PR TITLE
add config for houstonchronicle.com

### DIFF
--- a/houstonchronicle.com.txt
+++ b/houstonchronicle.com.txt
@@ -1,0 +1,5 @@
+body: //p | //img | //div[@class='photo-caption']
+next_page_link: //ul[@class='pagination']//a[contains(text(), '»')]
+
+test_url: http://www.houstonchronicle.com/nasa/adrift/1/
+


### PR DESCRIPTION
this time i have checked with http://ftr.fivefilters.org/makefulltextfeed.php?url=http%3A%2F%2Fwww.houstonchronicle.com%2Fnasa%2Fadrift%2F1%2F&max=3 and it only shows the pictures and their caption, but no text.