### PR TITLE
LWN.net: Fix full text for Weekly Editions.

### DIFF
--- a/lwn.net.txt
+++ b/lwn.net.txt
@@ -5,6 +5,8 @@ tidy: yes
 prune: no
 
 single_page_link: //div[@class='ArticleText']//a[contains(text(), 'Full Story')]/@href
+single_page_link: concat(//div[@class='ArticleText']//a[contains(text(), 'Read more')]/@href, 'bigpage')
+if_page_contains: //div[@class='ArticleText']//a[contains(text(), 'Read more')]
 
 title: //h1
 


### PR DESCRIPTION
As discussed in https://github.com/fivefilters/ftr-site-config/commit/fa1be0ba669893a8de6b6906ce273043d27eaa7d, here the fix.