### PR TITLE
thegap.at: Add site config.

### DIFF
--- a/thegap.at.txt
+++ b/thegap.at.txt
@@ -1,0 +1,41 @@
+prune: no
+tidy: no
+
+title: //h1
+strip: //h1
+
+date: //span[contains(concat(' ', normalize-space(@class), ' '), ' date ')]
+strip: //span[contains(concat(' ', normalize-space(@class), ' '), ' date ')]
+
+# Article
+
+author: normalize-space(substring-after(//div[@class='artikel']/p[1], 'von '))
+strip: //div[@class='artikel']/p[1]
+
+next_page_link: //a[@class='but weiter']/@href
+strip: //div[@class='browsetext']
+
+body: //div[@class='artikel']
+strip: //h5
+strip: //div[@class='copyrights']
+strip: //div[@class='textbox']
+strip: (//div[@class='artikel']//br)[1]
+strip: //div[@class='clear']
+strip: //p[starts-with(., 'Weiter zu:')]
+strip: //a[@name='minislide']
+strip: //div[@class='kommentare']
+
+# Slideshows
+
+author: normalize-space(substring-after(//div[@id='normal']/p[1], 'von '))
+strip: //div[@id='normal']/p[1]
+
+body: //div[@id='normal']
+next_page_link: //a[@class='next']/@href
+strip: //a[@class='next']
+strip: //a[@class='prev']
+strip: (//div[@id='normal']//br)[1]
+
+test_url: http://www.thegap.at/rubriken/stories/artikel/lecko-mio/
+test_url: http://www.thegap.at/rubriken/stories/artikel/die-frauen-im-arkadenhof/
+test_url: http://www.thegap.at/rubriken/stories/artikel/nothilfe-im-wandel/


### PR DESCRIPTION
#thegap.at uses relative URLs and a base tag in the HTML code. Handling of such URLs (i.e. making them absolute) is not supported by Full-Text RSS as of version 3.6 i.e. only the first page is extracted.

I've created a simple patch that adds support to Full-Text RSS for such pages:

```diff
commit 7e16042b6453d3b8a072763d0eb4d1c13ffa0207
Author: Lukas Anzinger <lukas@lukasanzinger.at>
Date:   Wed Jul 27 13:56:25 2016 +0200

    Use base URL to make absolute URLs for single or next page URLs.

diff --git a/makefulltextfeed.php b/makefulltextfeed.php
index e4896e4..914105c 100644
--- a/makefulltextfeed.php
+++ b/makefulltextfeed.php
@@ -811,6 +811,9 @@ foreach ($items as $key => $item) {
                                        continue; // skip this feed item entry
                                }
                        }
+                       $base_url = get_base_url($readability->dom);
+                       if (!$base_url) $base_url = $effective_url;
+                       else debug('Extracted base URL: ' . $base_url);
                        $content_block = ($extract_result) ? $extractor->getContent() : null;                   
                        $extracted_title = ($extract_result) ? $extractor->getTitle() : '';
                        // Deal with multi-page articles
@@ -824,8 +827,8 @@ foreach ($items as $key => $item) {
                                while ($next_page_url = $extractor->getNextPageUrl()) {
                                        debug('--------');
                                        debug('Processing next page: '.$next_page_url);
-                                       // If we've got URL, resolve against $url
-                                       if ($next_page_url = make_absolute_str($effective_url, $next_page_url)) {
+                                       // If we've got URL, resolve against $base_url
+                                       if ($next_page_url = make_absolute_str($base_url, $next_page_url)) {
                                                // check it's not what we have already!
                                                if (!in_array($next_page_url, $multi_page_urls)) {
                                                        // it's not, so let's attempt to fetch it
@@ -891,8 +894,6 @@ foreach ($items as $key => $item) {
                } else {
                        $readability->clean($content_block, 'select');
                        if ($options->rewrite_relative_urls) {
-                               $base_url = get_base_url($readability->dom);
-                               if (!$base_url) $base_url = $effective_url;
                                // rewrite URLs
                                make_absolute($base_url, $content_block);
                        }
@@ -1469,8 +1470,11 @@ function get_single_page($item, $html, $url) {
                                }
                        }
                }
-               // If we've got URL, resolve against $url
-               if (isset($single_page_url) && ($single_page_url = make_absolute_str($url, $single_page_url))) {
+               $base_url = get_base_url($readability->dom);
+               if (!$base_url) $base_url = $url;
+               else debug('Extracted base URL: ' . $base_url);
+               // If we've got URL, resolve against $base_url
+               if (isset($single_page_url) && ($single_page_url = make_absolute_str($base_url, $single_page_url))) {
                        // check it's not what we have already!
                        if ($single_page_url != $url) {
                                // it's not, so let's try to fetch it...
```

It's based on Full-Text RSS 3.6. I hope the patch is useful and can be shipped with the next release.

Cheers,

Lukas