### PR TITLE
Remove pocketnow.com

### DIFF
--- a/pocketnow.com.txt
+++ b/pocketnow.com.txt
@@ -1,3 +1,0 @@
-body: //img[@itemprop='image'] | //div[@itemprop='articleBody']
-
-test_url: http://pocketnow.com/2015/12/04/htc-hd2-marshmallow


### PR DESCRIPTION
New site layout breaks selectors. It works perfectly without provided rule.