### PR TITLE
fix elektroniknet.de.txt

### DIFF
--- a/elektroniknet.de.txt
+++ b/elektroniknet.de.txt
@@ -1,27 +1,10 @@
-title: //h1
-date: //div[@class='datum']
-single_page_link: //a[contains(@href, '?type=99')]
+date: //time
+next_page_link: //li[@class='next']//a
 
-# this hack preserves the intro text, because it would be striped otherwise if the title is set to //h1
-dissolve: //div[@class='artikelMeldung']
+# 1 page
+test_url: http://www.elektroniknet.de/elektronik-automotive/wirtschaft/aus-quattro-gmbh-wird-audi-sport-136464.html
+test_contains: etwa 1.200 Mitarbeiter an den Standorten Neckarsulm und Ingolstadt
 
-
-strip_id_or_class: anzeige
-strip_id_or_class: top_page_navigation
-strip_id_or_class: cr_image_container
-strip_id_or_class: cr_image_reference
-strip_id_or_class: cr_image_icon
-strip_id_or_class: _close_txt
-strip_id_or_class: _close_ico
-strip_id_or_class: clearer
-
-strip://h1
-strip://h6
-strip://div[contains(@id, 'plista')]
-strip://img[contains(@id,'tiny')]
-strip://img[@class='cr_image']
-
-# strip url at the top
-strip: //p[@style='font-size: 10px;']
-
-test_url: http://www.elektroniknet.de/automotive/technik-know-how/sicherheitselektronik/article/87717/0/Besser_als_die_Wirklichkeit/
+# 2 pages
+test_url: http://www.elektroniknet.de/elektronik-automotive/sonstiges/machine-learning-wird-demnaechst-massiv-an-bedeutung-gewinnen-136362.html
+test_contains: Ende 2014 übernahm er seine heutige Position als CEO von MBRDNA


### PR DESCRIPTION
This commit fixes the outdated config for elektroniknet.de, which was already detected by the test http://siteconfig.fivefilters.org/test/