### PR TITLE
fixes retrieving title in heise autos

### DIFF
--- a/heise.de.txt
+++ b/heise.de.txt
@@ -3,7 +3,6 @@
 
 prune: no
 
-title: //article/h1 | //h1
 date: //p[@class='news_datum']
 author: //span[@class='author']
 
@@ -59,3 +58,4 @@ test_url: http://www.heise.de/newsticker/meldung/Ueberwachungstechnik-Die-global
 test_url: http://www.heise.de/newsticker/meldung/Bodenradar-fuer-selbstfahrende-Autos-horcht-unter-die-Strasse-3273941.html
 test_url: http://www.heise.de/tp/artikel/49/49473/1.html
 test_url: http://www.heise.de/ct/artikel/Die-Neuerungen-von-Linux-3-15-2196231.html
+test_url: http://heise.de/-3527918


### PR DESCRIPTION
adds a new test url pointing to a heise autos article, which is http://heise.de/-3527918 and gets resolved to https://www.heise.de/autos/artikel/China-Sondersteuer-auf-besonders-teure-Autos-3527918.html?view=print
The latter contains an h1 tag, which does not include the real title of
the article, but instead the date of the article:

`<h1><span class="untertitel">01.12.2016</span></h1>`

Removing the title param from this config fixes this issue, also not
destroying fetching title of other heise.de test_urls and keeping those
intact.