### PR TITLE
fixes warning reported by the test that test url and file name differ

### DIFF
--- a/sz.de.txt
+++ b/sz.de.txt
@@ -7,4 +7,5 @@ strip: //p[@class="anzeige"]
 strip: //section[@class="authors"]
 strip: //div[contains(@class, "embed")]
 
-test_url: http://www.sueddeutsche.de/muenchen/mietshaus-am-gaertnerplatz-alles-muss-raus-1.1556693
+test_url: http://sz.de/1.1556693
+test_contains: ist selbst der alte Eigentümer erstaunt


### PR DESCRIPTION
The short url is pointing to the same article as the long url. Also a test
string is added, which should be in the content when retrieving the test
article.