### PR TITLE
fixes next_page_link detection for heise-ct

### DIFF
--- a/heise.de.txt
+++ b/heise.de.txt
@@ -49,7 +49,7 @@ replace_string(<div class="heisebox">): <blockquote>
 single_page_link: //a[contains(@href, '?view=print')]
 single_page_link: //a[contains(@title, 'Druck')]
 
-next_page_link: //a[@class='next']
+next_page_link: //a[@class='next' and not(contains(text(), 'Artikel'))]
 next_page_link: //a[@title='vor']
 next_page_link: //a[@rel='next']
 


### PR DESCRIPTION
This commit fixes the next_page_link detection for heise.de/ct/
articles, where the next-link (\<a\> with class=next) refers to the next
article and not to the next page. Therefore i added a check, that the
link text does not contain the word "Artikel".

Without that check all consecutive articles are fetched, altough they
are new articles and not a follow-up page of the same article.

e.g.:

https://www.heise.de/ct/ausgabe/2017-6-DVB-T2-HD-startet-in-Deutschland-3636637.html