### PR TITLE
Updated mobile.twitter.com

### DIFF
--- a/mobile.twitter.com.txt
+++ b/mobile.twitter.com.txt
@@ -1,4 +1,5 @@
 # mobile site (automatic redirect - noscript meta refresh)
+title: concat("Tweet from ", (//*[contains(@class, 'UserNames-displayName') or contains(@class, 'fullname')])[1])
 author: (//*[contains(@class, 'UserNames-displayName') or contains(@class, 'fullname')])[1]
 body: (//div[contains(@class, 'TweetDetail-text') or contains(@class, 'tweet-text')])[1]
 date: (//div[contains(@class, 'TweetDetail-timeAndGeo') or contains(@class, 'metadata')])[1]


### PR DESCRIPTION
Because mobile.twitter.com always has "Twitter" for its title page, I think it's better to change the title to have "Tweet from username".