### PR TITLE
Update amazon.com.txt

### DIFF
--- a/amazon.com.txt
+++ b/amazon.com.txt
@@ -16,4 +16,6 @@ strip_id_or_class: expandPS
 strip_id_or_class: psPlaceHolde
 strip: //li[contains(., 'update product info') or contains(., 'give feedback on images')]
 
+http_header(user-agent): PHP/5.3
+
 test_url: http://www.amazon.com/Common-Sense-Forestry-Living-Mother/dp/1931498210/


### PR DESCRIPTION
Looks like the default user agent force Amazon to return a 403

Related to:
- https://github.com/fivefilters/ftr-site-config/issues/304
- https://github.com/wallabag/wallabag/issues/3230