### PR TITLE
Updated for format used on their 'interactive' pages

### DIFF
--- a/nytimes.com.txt
+++ b/nytimes.com.txt
@@ -1,6 +1,7 @@
 title://h1[@class="articleHeadline"]
 body://div[@id="article"]
 body://*[@itemprop="articleBody"]
+body: //div[contains(concat(' ',normalize-space(@class),' '),' g-body-article-container ')]
 strip_id_or_class:articleTools
 strip_id_or_class:readerscomment
 #strip://div[contains(@class, "articleInline runaroundLeft")]
@@ -51,3 +52,4 @@ test_url: http://www.nytimes.com/2013/03/25/world/middleeast/israeli-military-re
 test_url: http://www.nytimes.com/2013/08/15/nyregion/when-the-new-york-city-subway-ran-without-rails.html
 test_url: http://www.nytimes.com/2004/02/29/weekinreview/correspondence-class-consciousness-china-s-wealthy-live-creed-hobbes-darwin-meet.html
 test_url: http://www.nytimes.com/2014/06/19/opinion/gail-collins-romney-and-the-2016-contenders-huddle.html
+test_url: https://www.nytimes.com/interactive/2015/12/16/upshot/100000004092329.app.html?_r=2


### PR DESCRIPTION
The NY Times Interactive pages have a format that couldn't be parsed. I've added code generated from the siteconfig tool for this and included a test URL for it.