### PR TITLE
Remove replacement of script

### DIFF
--- a/nytimes.com.txt
+++ b/nytimes.com.txt
@@ -26,11 +26,6 @@ strip: //p[@class='caption']//a[contains(., 'More Photos')]
 prune: no
 tidy: no
 
-find_string: <script 
-replace_string: <div style="display:none" 
-find_string: </script>
-replace_string: </div>
-
 date: substring-after(//*[contains(@class, 'dateline')], 'Published:')
 
 single_page_link: //link[contains(@href, 'pagewanted=all')]


### PR DESCRIPTION
It generates too much noise and badly handle some closing script tag which generate a whole div with a `display:none` which is then removed because being `display:none`.

Will fix https://github.com/wallabag/wallabag/issues/1979