### PR TITLE
Create blogs.sciencemag.org.txt

### DIFF
--- a/blogs.sciencemag.org.txt
+++ b/blogs.sciencemag.org.txt
@@ -1,0 +1,12 @@
+title: //h1
+
+author: //a[@rel='author']
+
+# Publication date
+date: //time
+
+body: //div[@class='article__body']
+
+prune: no
+
+test_url: http://blogs.sciencemag.org/pipeline/archives/2017/08/23/ultrasound-for-brain-drug-delivery-not-so-fast


### PR DESCRIPTION
Tested except for the author field which is not directly used by wallabag.
On the website, the code is `<a href='...' rel='author external'>Author name</a>`; I do not know if `author: //a[@rel='author']` is enough to pick it up.