### PR TITLE
Update blogs.sciencemag.org.txt

### DIFF
--- a/blogs.sciencemag.org.txt
+++ b/blogs.sciencemag.org.txt
@@ -1,6 +1,6 @@
 title: //h1
 
-author: //a[@rel='author']
+author: //a[contains(@rel, 'author')]
 
 # Publication date
 date: //time


### PR DESCRIPTION
As explained [here](https://github.com/fivefilters/ftr-site-config/pull/329#issuecomment-325186419), modification to match `<a href='...' rel="author external">`.
I checked that no author tag in the website (as it is right now) could match despite the quite "large" possibilities with `contains`.