### PR TITLE
Update washingtonpost.com.txt

### DIFF
--- a/washingtonpost.com.txt
+++ b/washingtonpost.com.txt
@@ -21,6 +21,7 @@ strip://div[@class="module component todays-paper-module curved"]
 strip://div[@class="module component live-qa curved img-border"]
 strip://div[@class="module component newsletter-signup curved"]
 strip://div[@class="module featured-stories component curved img-border"]
+strip://h3[@property="dc.creator"]
 
 strip_id_or_class: carousel
 strip_id_or_class: toolbar


### PR DESCRIPTION
For some reason the retrieved content doesn't have `<span class="pb-byline" itemprop="author" itemscope="" itemtype="http://schema.org/Person">` but a mysterious `<h3 property="dc.creator">`. Since authors are removed after being matched, the element stay like that: `<h3 property="dc.creator">By  and ,</h3>`
Authors are matched so we can safely remove that element.

Related https://github.com/j0k3r/graby/issues/103