### PR TITLE
Globally replace amp-img tag

### DIFF
--- a/global.txt
+++ b/global.txt
@@ -16,3 +16,9 @@ strip_image_src: doubleclick.net
 #replace_string: <div style="display:none" 
 #find_string: </script>
 #replace_string: </div>
+
+# convert amp image tag to html image tag
+find_string: <amp-img
+replace_string: <img
+find_string: </amp-img>
+replace_string: 


### PR DESCRIPTION
I don't know if it's the best place to globally handle a pattern.

Some [url](http://www.houstonchronicle.com/local/gray-matters/amp/I-downloaded-an-app-And-suddenly-I-was-talking-12172506.php) are fetched as AMP version so we need to convert amp tags to html one (at least for image)