### PR TITLE
Adding config for us-cert.gov alerts

### DIFF
--- a/us-cert.gov.txt
+++ b/us-cert.gov.txt
@@ -1,0 +1,9 @@
+# Page title
+title: //h1[@id='page-title']
+# Page subtitle
+title: //h2[@id='page-sub-title']
+# Page metadata
+date: //footer[contains(concat(' ',normalize-space(@class),' '),' submitted ')]
+# Page body
+body: //article[contains(concat(' ',normalize-space(@class),' '),' node ')]//div[contains(concat(' ',normalize-space(@class),' '),' content ') and (contains(concat(' ',normalize-space(@class),' '),' clearfix '))]
+test_url: https://www.us-cert.gov/ncas/alerts/TA17-181A


### PR DESCRIPTION
US-Cert alerts (see https://www.us-cert.gov/ncas/alerts/) are not currently being parsed, so I've added a config to parse them. I'm not very familiar with the proper format for a site config file, so let me know if there's something I should change to make it more effective. I just tried to model it after some of the existing configs in this repo.

Thanks!