### PR TITLE
fix heise.de title detection

### DIFF
--- a/heise.de.txt
+++ b/heise.de.txt
@@ -6,6 +6,8 @@ prune: no
 date: //p[@class='news_datum']
 author: //span[@class='author']
 
+title: //h1
+title: //h2
 body: //article | //div[@class='meldung_wrapper']
 
 strip: //nav


### PR DESCRIPTION
Fixes the title detection of heise.de articles. This config used default
<title> tag, but this tag is polluted with the string "Druckversion - "
and sometimes with " | heise online". Using the h1 (telepolis) or h2
(rest of heise) tag gives us the correct clean title.