### PR TITLE
fix heise.de title detection

### DIFF
--- a/heise.de.txt
+++ b/heise.de.txt
@@ -42,6 +42,12 @@ strip_id_or_class: ad_
 # Some optimizations
 replace_string(<h5>): <h2>
 replace_string(</h5>): </h2>
+replace_string(<title>Druckversion - ): <title>
+replace_string( | heise online</title>): </title>
+replace_string( | c't Magazin</title>): </title>
+replace_string( | Telepolis</title>): </title>
+replace_string( | heise Security</title>): </title>
+replace_string( | heise Autos</title>): </title>
 # this line breaks the parser
 #replace_string(<span class="bild_rechts" style="width:): <p "
 replace_string(<div class="heisebox">): <blockquote>


### PR DESCRIPTION
Fixes the title detection of heise.de articles. This config used default
<title> tag, but this tag is polluted with the prefix string
"Druckversion - " and sometimes with suffixed e.g with " | heise online"
Therefore we replace those strings with nothing.