### PR TITLE
Add a marmiton.org info file

### DIFF
--- a/marmiton.org.txt
+++ b/marmiton.org.txt
@@ -1,0 +1,6 @@
+title: //h1[@class="main-title"]
+author: //span[@class="recipe-author__name"]
+body: //div[@id="sticky-desktop-only"]
+strip: //div[@id="bloc-video"]
+
+test_url: http://www.marmiton.org/recettes/recette_gateau-au-chocolat-fondant-rapide_166352.aspx


### PR DESCRIPTION
Hi,

First, this is my first contribution to this repo, so please let me know if I missed something. I am using [wallabag](http://wallabag.org/) which apparently makes use of these config under the hood to extract content from articles, and the recipe from `marmiton.org` (in the `test_url`) was not correctly extracted.

I guess this PR should fix this.

Thanks