### PR TITLE
Update taz.de.txt

### DIFF
--- a/taz.de.txt
+++ b/taz.de.txt
@@ -1,9 +1,9 @@
-date: //div[@class='secthead']
-body: (//div[@class='sectbody'])[1]
-title: concat(//div[@class='sectbody']/h4,': ',//div[@class='sectbody']/h1)
-author: //span[@class='author']
+date: //li[@class='date']
+body: (//article[@class='sectbody'])[1]
+title: concat(//article[@class='sectbody']/h4,': ',//article[@class='sectbody']/h1)
+author: //a[@class='author']/h4
 strip: //p[@class='caption']
 strip_id_or_class: ad_bin
 strip_id_or_class: rack
 
-test_url: http://www.taz.de/Protestbewegung-Occupy/!80188/
+test_url: https://www.taz.de/!5504959/


### PR DESCRIPTION
The old site config for taz.de wasn't working anymore (due to website layout changes).
This patch fixes the wrong tags.
(Fixed pull request)