### PR TITLE
Updating theguardian.com

### DIFF
--- a/theguardian.com.txt
+++ b/theguardian.com.txt
@@ -1,9 +1,5 @@
-title: //h1[@articleprop='headline']
-
 body: //article
 body: //div[contains(concat(' ',normalize-space(@class),' '),' content__main ')]//div[contains(concat(' ',normalize-space(@class),' '),' gs-container ')]
-strip: //article/header/div[contains(@class, 'content__header')]
-strip: //article/header/div[contains(@class, 'content__logo-container')]
 strip: //article//div[contains(@class, 'content__secondary-column')]
 strip: //article//aside
 strip: //article//div[contains(@class, 'block-share')]
@@ -15,6 +11,10 @@ strip: //article//script
 strip: //article//figure[contains(@class, 'element-audio')]
 strip: //article//a[contains(@style, 'display: none')]
 strip: //article/div[@class='paidfor-band']
+strip: //header
+strip: //div[@class='content__main-column']
+strip: //div[contains(@class, 'content-footer')]
+strip: //footer
 
 strip_id_or_class: hide-on-mobile
 strip_id_or_class: reveal-caption


### PR DESCRIPTION
Adding a rule to strip out the entire header section, which solves several issues. Removing a couple of redundant rules.