### PR TITLE
Adding theonion subdomains

### DIFF
--- a/.theonion.com.txt
+++ b/.theonion.com.txt
@@ -1,0 +1,10 @@
+title: //h2[@class='title'] | //h1[contains(concat(' ',normalize-space(@class),' '),'headline')]
+date: substring-before(//p[@class='meta'], '|')
+body: //div[@class='article_body'] | //div[@class='story'] | //div[contains(concat(' ',normalize-space(@class),' '),'post-content')]
+
+strip: //h2[@class='title']
+strip: //p[@class='meta']
+strip: //div[@class='ga_section']
+strip: //div[@id='recent_slider']
+
+test_url: https://politics.theonion.com/inconsolable-jeff-sessions-tries-to-commit-suicide-by-s-1826462420


### PR DESCRIPTION
politics.theonion.com doesn't work with theonion.com.txt but I'm not
sure if I should move theonion.com.txt to .theonion.com.txt or create
this new file. Please let me know what you would prefer.

Also looks like some of the section names have
changed. Merging those in with | per
http://help.fivefilters.org/customer/en/portal/articles/223153-site-patterns
so that theonion can still be scraped if they move back to an older
format.