### PR TITLE
WIP: Create montelimar-news.fr.txt

### DIFF
--- a/montelimar-news.fr.txt
+++ b/montelimar-news.fr.txt
@@ -1,0 +1,12 @@
+
+title: //a[contains(concat(' ',normalize-space(@class),' '),' titre_news ')]
+body: //div[@id='titre']
+
+find_string: lang="en-US"
+replace_string: lang="fr-FR"
+
+strip_id_or_class: titre_news
+strip_id_or_class: group1
+
+test_url: http://www.montelimar-news.fr/article/parfum-de-jazz-en-drome-provencale/1/9654.html#955c5
+


### PR DESCRIPTION
There is an encoding issue with this website.
No encoding is specified in the HTML (the incorrect UTF-8 charset has been commented out).
Firefox automatically detect that encoding might be "windows-1252" but I don't know how to force it with FiveFilters.
