### PR TITLE
technologyreview.com: strip extraneous content

### DIFF
--- a/technologyreview.com.txt
+++ b/technologyreview.com.txt
@@ -12,6 +12,9 @@ author: //div[@class='view-byline']/div[@class='meta']/h2[1]
 date: //div[@class='view-byline']/div[@class='meta']/h2[2]
 
 strip_id_or_class: l-article-list
+strip_id_or_class: l-automated-related--single
+strip_id_or_class: l-cta--left
+strip_id_or_class: l-automated-trending--ordered
 
 next_page_link: //section[@class='pagination']/a[contains(@class, 'continue')]
 test_url: http://www.technologyreview.com/news/427567/facebooks-telescope-on-human-behavior/


### PR DESCRIPTION
Strip "Recommended", "Related" and "newsletter sign up" widgets