### PR TITLE
theatlantic: skip JSON-LD data as the title is incorrectly set

### DIFF
--- a/theatlantic.com.txt
+++ b/theatlantic.com.txt
@@ -24,6 +24,8 @@ strip: //div[@class='earthbox']
 
 native_ad_clue: //meta[@property="og:url" and contains(@content, '/sponsored/')]
 
+skip_json_ld: yes
+
 #multi-page article (not multi-page anymore)
 test_url: http://www.theatlantic.com/magazine/archive/2014/12/the-real-roots-of-midlife-crisis/382235/
 test_contains: The curve tends to evince itself


### PR DESCRIPTION
The title provided in the JSON-LD array is not the title of the fetched
content.