### PR TITLE
.blogspot.com: replace noscript tag

### DIFF
--- a/.blogspot.com.txt
+++ b/.blogspot.com.txt
@@ -5,6 +5,9 @@ body://div[contains(@class,'entry-content')]
 strip_comments:no
 prune:no
 
+replace_string(<noscript>): <div>
+replace_string(</noscript>): </div>
+
 tidy:yes
 
 test_url: http://themerryone.blogspot.com/2010/08/new-move-new-blog.html


### PR DESCRIPTION
Some blogs (e.g. googleblog.com) embed their content in script tags with
a version for javascript-less browsers using noscript. This commit
replaces the noscript tag with a simple div to prevent readers
from rendering an empty page.