### PR TITLE
Site & paywall configuration for lepoint.fr

### DIFF
--- a/lepoint.fr.txt
+++ b/lepoint.fr.txt
@@ -1,7 +1,15 @@
-title: //meta[@property='og:title']/@content
+title: //h1
 body: //h2[@class='art-chapeau'] | //div[@class='art-text']
 
 # Remove "Lire aussi" and "À lire aussi" links
 strip: //p/strong[contains(text(), 'aussi') and a]
+
+requires_login: true
+
+login_uri: https://moncompte.lepoint.fr
+login_username_field: email
+login_password_field: password
+login_extra_fields: sessionouverte
+not_logged_in_xpath: //aside[@id='article-reserve-aux-abonnes']
 
 test_url: https://www.lepoint.fr/politique/dans-les-coulisses-d-un-couac-gouvernemental-19-12-2018-2280794_20.php


### PR DESCRIPTION
Here is the site configuration allowing for:
- fetching of content on Le Point (French journal) website;
- access to paywalled articles with wallabag.

Tested on wallabag 2.3.5.