### PR TITLE
Update prospectmagazine.co.uk with shortest code and paywall support

### DIFF
--- a/prospectmagazine.co.uk.txt
+++ b/prospectmagazine.co.uk.txt
@@ -1,26 +1,9 @@
-#basics
-author: (//div[contains(@class,'author')])[1]
-date: substring-before(//a[@class='issue'], '&mdash;')
-#body://div[@class = 'entry']
-# use this until move_into support is ready
-body: //div[@class = 'entry' or @class='standfirst' or @class='lead_image']
+body: //div[contains(concat(' ',normalize-space(@id),' '),' post_content ')]
 
-#moves header image and tagline into body
-move_into(//div[@class='entry']/div)://div[@class = 'lead_image']
-move_into(//div[@class='entry']/div)://div[@class = 'standfirst']
+requires_login: yes
+login_uri: https://www.prospectmagazine.co.uk/wordpress/wp-login.php
+login_username_field: log
+login_password_field: pwd
+not_logged_in_xpath: //body[@class="login-popup-link"]
 
-
-# moves author info to end of text
-move_into(//p[strong[string(.) = 'Follow Prospect on Twitter']])://div[@id='sidebar_content']/p/em
-
-prune: no
-
-# strips social links
-strip_id_or_class:login-status
-strip_id_or_class:shareinpost
-strip_id_or_class:content_subscribe
-strip_id_or_class:postinfo
-strip_id_or_class:postutils
-strip_id_or_class:comments
-strip://strong[string(.) = 'Follow Prospect on Twitter']
-test_url: http://www.prospectmagazine.co.uk/2011/07/postmodernism-is-dead-va-exhibition-age-of-authenticism/
+test_url: https://www.prospectmagazine.co.uk/magazine/when-it-comes-to-mental-health-the-best-strategy-can-be-have-no-strategy


### PR DESCRIPTION
Support for prospectmagazine.co.uk is very old and does not include paywall support.

Relates to wallabag/wallabag#3439