### PR TITLE
add class stripping for synbioz.com

### DIFF
--- a/synbioz.com.txt
+++ b/synbioz.com.txt
@@ -6,4 +6,6 @@ body: //div[contains(concat(' ',normalize-space(@class),' '),' post-body ')]
 
 date: //time[contains(concat(' ',normalize-space(@class),' '),' post-date ')]/@datetime
 
+strip_id_or_class: hs-cta-img
+
 test_url: https://www.synbioz.com/blog/hebergement-applications-web


### PR DESCRIPTION
Remove image in the middle of the article with class `hs-cts-img`