### PR TITLE
Added strip commands to ici.radio-canada.ca

### DIFF
--- a/ici.radio-canada.ca.txt
+++ b/ici.radio-canada.ca.txt
@@ -6,7 +6,10 @@ strip: //header
 strip: //figure
 strip: //div[@class='framed']
 strip: //form
+strip: //div[contains(@class, 'newsstory-share-social-layout-wrapper')]
+strip: //article[contains(@class, 'card-style')]
 
 test_url: http://ici.radio-canada.ca/nouvelle/1003322/lexique-mots-neige-hiver-guy-bertrand
 test_url: http://ici.radio-canada.ca/tele/deuxieme-chance/inscription/
 test_url: http://ici.radio-canada.ca/emissions/aujourd_hui_l_histoire/2016-2017/chronique.asp?idChronique=423294
+test_url: https://ici.radio-canada.ca/rss/4159


### PR DESCRIPTION
The strip directives remove the sharing links at the top, and the "other news" at the bottom for an article, leaving only the article's content.