### PR TITLE
make taz.de work again, closes #417

### DIFF
--- a/taz.de.txt
+++ b/taz.de.txt
@@ -4,6 +4,5 @@ title: concat(//article[@class='sectbody']/h4,': ',//article[@class='sectbody']/
 author: //a[@class='author']/h4
 strip: //p[@class='caption']
 strip_id_or_class: ad_bin
-strip_id_or_class: rack
 
 test_url: https://www.taz.de/!5504959/


### PR DESCRIPTION
Tested with https://f43.me/feed/test and a self-hosted wallabag -- but without much knowledge. Without the deleted line, articles are fetched again properly.