### PR TITLE
Add preparedfood.com.txt

### DIFF
--- a/preparedfoods.com.txt
+++ b/preparedfoods.com.txt
@@ -2,3 +2,5 @@ title: //h1[@class='headline']
 date: //div[@class='date']
 author: //div[@class='author']//a
 body: //div[contains(concat(" ", normalize-space(@class), " "), " gsd-paywall ")]
+
+test_url: https://www.preparedfoods.com/articles/122242-flavor-boosters-maskers

--- a/preparedfoods.com.txt
+++ b/preparedfoods.com.txt
@@ -1,0 +1,4 @@
+title: //h1[@class='headline']
+date: //div[@class='date']
+author: //div[@class='author']//a
+body: //div[contains(concat(" ", normalize-space(@class), " "), " gsd-paywall ")]


### PR DESCRIPTION
New site config for the food production magazine preparedfood.com. Written to get around their obnoxious cookie notice.

Tested to be fully functional in the latest version of wallabag via direct addition of this config file to the vendor site-config directory of my wallabag instance.

Thanks!