### PR TITLE
Shz.de - Rewrite to fetch content from AMP page instead

### DIFF
--- a/shz.de.txt
+++ b/shz.de.txt
@@ -1,16 +1,22 @@
+# Redirect to AMP page to bypass blocking
+single_page_link: //link[@rel='amphtml']
+
 # Title not working correctly in Wallabag
-title: //meta[@name='dc.title']/@content
-author: //meta[@name='author']/@content
+title: //h1[@class='headline']
+author: //span[@itemprop='author']
 date: substring-before(//span[@class='info-text'], ', <br>')
 body: //div[@class='span2.article']
 
 # Strip clutter
-strip: //img[@class='plus-box__image']
-strip: //div[@class='plus-box__text']
-strip: //a[@href='https://www.shz.de/plus/']
-strip: //div[@class='startpage']
+strip_id_or_class: flying-carpet-wrapper
+strip_id_or_class: blurred
+strip_id_or_class: ampstart-card
+strip: //img[@class='slide__image'][1]
+strip: //img[@class='slide__image'][2]
+strip: //div[@class='inline-image__img']//img[1]
+strip: //img[contains(concat(' ',normalize-space(@class),' '),' teaser-plus ')]
+strip: //div[@amp-access='data.reduced']
 
-# Appear to be Google
-http_header(User-agent): GoogleBot/4.51
-
-test-url: https://www.shz.de/lokales/landeszeitung/eine-ampel-fuer-die-b-202-id23776527.html
+# Tests
+test_url: https://www.shz.de/deutschland-welt/politik/Therapien-gegen-Homo-und-Transsexualitaet-sollen-verboten-werden-id26742562.html
+test_url: https://www.shz.de/lokales/schleibote/australische-pinguine-tragen-jetzt-pullis-aus-kappeln-id26733692.html

--- a/shz.de.txt
+++ b/shz.de.txt
@@ -1,7 +1,8 @@
 # Redirect to AMP page to bypass blocking
 single_page_link: //link[@rel='amphtml']
 
-# Title not working correctly in Wallabag
+skip_json_ld: yes
+
 title: //h1[@class='headline']
 author: //span[@itemprop='author']
 date: substring-before(//span[@class='info-text'], ', <br>')


### PR DESCRIPTION
Faking the user-agent does not work anylonger, but they publish the whole content on the AMP page.
I don't know if there is a more elegant way around this, but this seems to work fine.

For unknown reasons does the extraction of the title not work, it always just uses the last part of the URL - for example: "amp_26733692"

Tested with latest Wallabag