### PR TITLE
taz.de - strip duplicate article title

### DIFF
--- a/taz.de.txt
+++ b/taz.de.txt
@@ -2,6 +2,8 @@ date: //li[@class='date']
 body: (//article[@class='sectbody'])[1]
 title: concat(//article[@class='sectbody']/h4,': ',//article[@class='sectbody']/h1)
 author: //a[@class='author']/h4
+
+strip: //h4[@xmlns]
 strip: //p[@class='caption']
 strip_id_or_class: ad_bin
 


### PR DESCRIPTION
Tested with latest wallabag