### PR TITLE
derstandard.at - strip non-article elements

### DIFF
--- a/derstandard.at.txt
+++ b/derstandard.at.txt
@@ -16,6 +16,8 @@ strip: //div[@id='feature-cover']
 strip: //div[@id='feature-meta']
 strip: //li[@class='empty']
 strip: //ul[@class='lookup-links']
+strip: //p[@class='article-pubdate']
+strip: //aside[@data-type='supplemental']
 
 http_header(Cookie): DSGVO_ZUSAGE_V1=true
 


### PR DESCRIPTION
- Removes call-to-action box at the end of the article
- Removes the publish date from the article

Tested with latest wallabag