### PR TITLE
Create perspective-daily.de.txt

### DIFF
--- a/perspective-daily.de.txt
+++ b/perspective-daily.de.txt
@@ -3,6 +3,8 @@
 
 strip: //cite
 
+skip_json_ld: yes
+
 requires_login: yes
 not_logged_in_xpath: //form[@id='signupForm']
 

--- a/perspective-daily.de.txt
+++ b/perspective-daily.de.txt
@@ -1,0 +1,15 @@
+# replace_string(<span class="info">): <div class="info">
+# strip: //span[@class="info"]
+
+strip: //cite
+
+requires_login: yes
+not_logged_in_xpath: //form[@id='signupForm']
+
+login_uri: https://perspective-daily.de/enrol/login
+login_username_field: email
+login_password_field: password
+
+login_extra_fields: csrfmiddlewaretoken=@=xpath('//input[@name="csrfmiddlewaretoken"]', request_html('https://perspective-daily.de/enrol/login'))
+
+test_url: https://perspective-daily.de/article/1212


### PR DESCRIPTION
This is a paywalled site that works with this config with my wallabag.

However, this site adds toggable extra-infos in their articles (tags: `<span class="info"></span>`). I couldn't manage to strip those (they are obviously not toggable in any non-interactive reader anymore), maybe someone can help me out here? [This link leads to a full-text-article](https://perspective-daily.de/article/1212/nqj6zJiZ), search for "Industriekapitalismus" and you will see what I mean with toggable extra-info.