### PR TITLE
Add hln.be and demorgen.be config

### DIFF
--- a/demorgen.be.txt
+++ b/demorgen.be.txt
@@ -1,0 +1,21 @@
+# get past the cookie wall
+http_header(cookie): pws=functional|analytics|content_recommendation|targeted_advertising|social_media; pwv=1
+
+# grab the author and date
+author: //a[@class='artstyle__byline__author']
+date: //time[@class='artstyle__byline__datetime']
+
+# grab article body
+body: //article[@class='artstyle fu--type-default artstyle--type-default']
+
+# strip category header
+strip: //h4[@class='artstyle__labels']
+
+# strip author, date and timestamp metadata
+strip: //section[@data-element-id='article-element-authors']
+
+# strip the "Lees ook" part at the bottom
+strip: //aside[@class='artstyle__editorial-tips']
+
+test_url: https://www.demorgen.be/nieuws/helft-belgische-moslims-is-fundamentalist~b2344ae6/
+test_contains: Helft Belgische moslims is fundamentalist

--- a/hln.be.txt
+++ b/hln.be.txt
@@ -1,0 +1,14 @@
+# get past the cookie wall
+http_header(cookie): pws=functional|analytics|content_recommendation|targeted_advertising|social_media; pwv=2
+
+# grab article body
+body: //article[@class='article fjs-article']
+
+# strip author, date and timestamp metadata
+strip: //ul[@class='article__metadata']
+
+# strip the "Meer over" part at the bottom
+strip: //div[@class='article__tag-list']
+
+test_url: https://www.hln.be/in-de-buurt/leuven/minister-geens-bezoekt-pop-up-naaiatelier-en-krijgt-modieus-mondmasker-aangemeten~a88e678d/
+test_contains: Minister Geens bezoekt pop-up naaiatelier en krijgt modieus mondmasker aangemeten


### PR DESCRIPTION
These sites need a config file to get past the cookie wall. They also
need help grabbing the article content. Without the config the article
intro gets skipped.