### PR TITLE
Update golem.de.txt

### DIFF
--- a/golem.de.txt
+++ b/golem.de.txt
@@ -1,6 +1,9 @@
 # Author: zinnober
 # Rewrite of original template which fetched the printer-version without pictures
 
+# As of 2020, this cookie is required to fetch articles because of the GDPR cookie warning
+http_header(Cookie): golem_consent20=cmp|200801
+
 tidy: no
 prune: no
 


### PR DESCRIPTION
A new cookie setting is required to fetch articles because of the GDPR cookie warning. I'm not sure if the value is static or changes with a new year.