### PR TITLE
Update arstechnica.com.txt

### DIFF
--- a/arstechnica.com.txt
+++ b/arstechnica.com.txt
@@ -1,12 +1,17 @@
+author: //p[@class='byline']/span[@class='author']
 author: //p[@class='byline']/a
+
 body: //div[contains(@class,'article-content')]
 strip: //h2[@class='title']
+strip: //div[contains(@class, 'pullbox)]
+
 strip_id_or_class: byline
 strip_id_or_class: story-sidebar
 prune: no
 
 date: //div[@class='byline']/span[@class='posted']//abbr/@original-title
 date: //div[@class='byline']/span[@class='posted']//abbr
+date: //*[@class='byline']//time[@class='date']
 
 title: //div[@id='story']//h2[@class='title']
 
@@ -16,9 +21,11 @@ native_ad_clue: //meta[@property="og:url" and contains(@content, '/sponsored/')]
 strip: //aside
 next_page_link: //nav//a[contains(text(), 'Next')]/@href
 next_page_link: //span[@class='numbers']//a/span[@class='next']/..
+next_page_link: //nav//a/span[contains(text(), 'Next')]/../@href
 
 test_url: http://arstechnica.com/tech-policy/news/2012/02/gigabit-internet-for-80-the-unlikely-success-of-californias-sonicnet.ars
 test_url: http://arstechnica.com/apple/2005/04/macosx-10-4/
+test_url: https://arstechnica.com/features/2020/10/the-space-operating-systems-booting-up-where-no-one-has-gone-before
 
-test_url: http://arstechnica.co.uk/science/2016/06/what-is-open-access-free-sharing-of-all-human-knowledge/
-test_url: http://arstechnica.co.uk/information-technology/2016/05/eben-moglen-gpl-online-advertising-is-becoming-a-perfect-despotism/
+# test_url: http://arstechnica.co.uk/science/2016/06/what-is-open-access-free-sharing-of-all-human-knowledge/
+# test_url: http://arstechnica.co.uk/information-technology/2016/05/eben-moglen-gpl-online-advertising-is-becoming-a-perfect-despotism/


### PR DESCRIPTION
The focus of this PR is a fix for the the multi-page articles.

Full list of changes below:
-   Add alternative way to detect "Next" link, author, date.
    -   Detecting the author still needs some work.
-   Add pullbox as item to be stripped from the content.
-   Comment out test URLs from the arstechnica.co.uk domain
    -   Triggered false warning among the tests.
-   Add test URL for the new Next link.