### PR TITLE
twitter.com: fix content fetching using custom UA

### DIFF
--- a/mobile.twitter.com.txt
+++ b/mobile.twitter.com.txt
@@ -6,6 +6,10 @@ date: (//div[contains(@class, 'TweetDetail-timeAndGeo') or contains(@class, 'met
 
 parser: html5php
 
+# Twitter does not show the content without JavaScript anymore
+# Using the Googlebot UA seems to give back the content, for now
+http_header(User-Agent): Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
+
 # avoid error if Twitter define that cookie first, because it contains invalid character
 http_header(Cookie): personalization_id=1;
 

--- a/twitter.com.txt
+++ b/twitter.com.txt
@@ -9,6 +9,10 @@ body: (//div[contains(@class, 'TweetDetail-text')])[1]
 
 parser: html5php
 
+# Twitter does not show the content without JavaScript anymore
+# Using the Googlebot UA seems to give back the content, for now
+http_header(User-Agent): Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
+
 # avoid error if Twitter define that cookie first, because it contains invalid character
 http_header(Cookie): personalization_id=1;
 


### PR DESCRIPTION
Twitter does not show the content without JavaScript anymore.
Using the Googlebot UA seems to give back the content, for now.