### PR TITLE
add site config for lightreading.com

### DIFF
--- a/lightreading.com.txt
+++ b/lightreading.com.txt
@@ -1,0 +1,6 @@
+date: //div[@itemprop='article-profile']//div[@class='byline']//span[@class='date']
+author: //div[@itemprop='article-profile']//div[@class='byline']//span[@class='allcaps']
+
+body: //div[contains(@class, 'article-main-body')]/article
+
+test_url: https://www.lightreading.com/4g3gwifi/eurobites-deutsche-telekom-o2-to-tackle-gray-spots-through-network-sharing/d/d-id/766728


### PR DESCRIPTION
We had been rolling our own [custom extractor](https://github.com/fossar/selfoss/blob/18ded07750d84df4a54aebe57522674cfede9ab9/src/spouts/rss/lightreading.php) in selfoss but it does not seem to work any more and site config will be more maintainable anyway.