### PR TITLE
add krautreporter.de

### DIFF
--- a/krautreporter.de.txt
+++ b/krautreporter.de.txt
@@ -1,0 +1,5 @@
+replace_string(<img src=): <img notused=
+replace_string(ix-path=): src=
+
+test_url: https://krautreporter.de/2244-stell-dir-vor-du-erbst-nazi-geld-was-machst-du?shared=c30432e7-4d96-42c5-85d3-354e1f90482d
+


### PR DESCRIPTION
fetching text works already fine, but images are lazy-loaded.
Therefore we use the img's ix-path attribute to get the
real image path instead of the original src, which only
contains an empty gif via data: notation.