### PR TITLE
Update alistapart.com.txt

### DIFF
--- a/alistapart.com.txt
+++ b/alistapart.com.txt
@@ -13,3 +13,4 @@ strip_id_or_class: aside-breaker
 prune: no
 test_url: http://www.alistapart.com/articles/organizing-mobile/
 test_url: https://alistapart.com/article/responsible-javascript-part-1
+test_contains: Modern layout engines like Flexbox and Grid

--- a/alistapart.com.txt
+++ b/alistapart.com.txt
@@ -1,15 +1,14 @@
-title: //h1[@class='entry-title']
-author: //main/article/header//span[@class='author vcard']
-date: //main/article/header//time[@class='entry-date published']
+title: //meta[@property="og:title"]/@content
+author: //main/article/header//span[@itemprop="author"]
+date: //meta[@property="article:published_time"]/@content
 
-body: //main/article//div[@class='entry-content']
+body: //main/article//div[contains(concat(' ',normalize-space(@class),' '),' entry-content ')]
 strip: //aside
-strip: //div[@class='aside-breaker']
-strip: //div[@class='ala-single-sidebar-wrapper']
-strip: //a[@class='subhead-anchor']
+strip: //div[contains(concat(' ',normalize-space(@class),' '),' ala-single-sidebar-wrapper ')]
+strip: //a[contains(@class, 'subhead-anchor')]
 strip: //footer
-strip: //div[@class="utility-side-bar"]
-strip_id_or_class: 'aside-breaker'
+strip: //div[contains(concat(' ',normalize-space(@class),' '),' utility-side-bar ')]
+strip_id_or_class: aside-breaker
 
 prune: no
 test_url: http://www.alistapart.com/articles/organizing-mobile/

--- a/alistapart.com.txt
+++ b/alistapart.com.txt
@@ -1,9 +1,12 @@
 title: //h1[@class='entry-title']
-author: //h2/a[@class='fn']
-date: //time[@itemprop='datePublished']
+author: //main/article/header//span[@class='author vcard']
+date: //main/article/header//time[@class='entry-date published']
 
-body: //div[@itemprop='articleBody']
+body: //main/article//div[@class='entry-content']
 strip: //aside
+strip: //div[@class='aside-breaker']
+strip: //div[@class='ala-single-sidebar-wrapper']
+strip: //a[@class='subhead-anchor']
 strip: //footer
 strip: //div[@class="utility-side-bar"]
 strip_id_or_class: 'aside-breaker'


### PR DESCRIPTION
Seems like they had an update to their HTML since 2019. Seems interesting that this is not listed as a failure on http://siteconfig.fivefilters.org/test/ since with this update it currently only extracts the title.