### PR TITLE
sanitizes quotes in embedded youtube iframe

### DIFF
--- a/youtube.com.txt
+++ b/youtube.com.txt
@@ -1,11 +1,18 @@
 title: //title
+# This site config will parse the XML pointed to by the 'single_page_link' by extracting
+# the embed iframe using find_string/replace_string
 body: //iframe
 
-find_string: <html>&lt;iframe 
-replace_string: <iframe id="video" 
+# Do minimal sanitization to make the iframe accessible via xpath
+find_string: <html>&lt;iframe
+replace_string: <iframe id="video"
 
 find_string: &gt;&lt;/iframe&gt;</html>
 replace_string: ></iframe>
+
+# Make all the properties of the iframe use regular encoding for quotes to avoid corruption
+find_string: &quot;
+replace_string: '
 
 single_page_link: //link[@type='text/xml+oembed']
 


### PR DESCRIPTION
I discovered and verified this using wallabag, I hope that's OK.   The problem is that this site config will parse an iframe which is URL encoded inside an XML document.  The existing config is reading that iframe with URL encoded quotes for each property instead of ASCII ones - `src=&quot;<the url>&quot;` instead of `src='<the url>'`.  This is corrupting the output, which is supposed to be a reusable iframe, as I understand it.  This change changes all the URL encoded quotes into ASCII, which is fixing the link in wallabag.