### PR TITLE
Create arxiv.org.txt

### DIFF
--- a/arxiv.org.txt
+++ b/arxiv.org.txt
@@ -1,0 +1,6 @@
+title: //h1[contains(concat(' ',normalize-space(@class),' '),' title ')]
+
+body: //blockquote[contains(concat(' ',normalize-space(@class),' '),' abstract ')]
+
+test_url: https://arxiv.org/abs/2009.03017
+test_url: https://arxiv.org/abs/2012.03780


### PR DESCRIPTION
Arxiv is a digital archive used by scientists to publish pre-print scientific puiblications (typically, not yet accepted for publication in a journal or conference, ...).

No such file exists and applications dependent on fivefilters (in my case, wallabag.it) fail on arxiv. The failure is reproduced on the test page.

This is a simple version: it can probably be improved! In particular:

- it would be nice to remove the `blockquote` (i.e. only get the content)
- check that the title is well extracted

but I was not able to figure out how.

Concerning the URL pattern, I'd propose to parse URLs of the form `arxiv.org/abs/.,.`. I tried to follow the naming convention in the README.md but I am not 100% certain.

Thanks !