### PR TITLE
Revert last change on lemonde.fr

### DIFF
--- a/lemonde.fr.txt
+++ b/lemonde.fr.txt
@@ -54,8 +54,8 @@ strip_id_or_class: message--register
 requires_login: yes
 
 login_uri: https://secure.lemonde.fr/sfuser/connexion
-login_username_field: email
-login_password_field: password
+login_username_field: connection[mail]
+login_password_field: connection[password]
 
 login_extra_fields: connection[_token]=@=xpath("//form//input[@id='connection__token']", request_html(config.getLoginUri()))
 


### PR DESCRIPTION
It appears that lemonde.fr rolled back their change on their login page.

This reverts commit 76918dbcd677d42bc7618f0d9e31fdd6427965c3.