### PR TITLE
update to heise.de rules

### DIFF
--- a/heise.de.txt
+++ b/heise.de.txt
@@ -44,6 +44,7 @@ strip: //p[@class='themen_foren']
 strip: //style
 strip: //span[@class='source']
 strip: //figure[@class='printversion__logo']
+strip: //figure[@class='branding']
 strip: //a-ad
 strip: //footer
 
@@ -60,9 +61,10 @@ strip_id_or_class: a-pvgs
 strip_id_or_class: a-pvg__body
 strip_id_or_class: teaser_adliste
 strip_id_or_class: a-article-header__service
-strip_id_or_class: legacy-img
 strip_id_or_class: opinary-widget-embed
 strip_id_or_class: article-sidebar
+strip_id_or_class: a-box__header
+strip_id_or_class: a-article-teaser
 
 # Strip Ads
 strip_id_or_class: ad_


### PR DESCRIPTION
* remove branding image
* get back legacy images (they are used in the article itself for illustation, e.g. see https://www.heise.de/-6217720)
* remove teasers for other articles
* remove article header from the article text