### PR TITLE
theguardian: keep svg and figcaption tags, prune content

### DIFF
--- a/theguardian.com.txt
+++ b/theguardian.com.txt
@@ -32,10 +32,6 @@ strip_id_or_class: site-message
 strip_id_or_class: contributions__epic
 strip_id_or_class: youtube-media-atom__overlay
 
-strip: //figcaption
-strip: //svg
-
-
 title: //h1[@articleprop='headline']
 author: //a[@rel='author']
 date: //article//time/@datetime
@@ -44,9 +40,6 @@ strip: //iframe[@srcdoc]
 
 native_ad_clue: //meta[@property='article:tag' and contains(@content, 'partner zone')]
 native_ad_clue: //meta[@property='video:tag' and contains(@content, 'partner zone')]
-
-prune: no
-tidy: no
 
 test_url: http://www.theguardian.com/world/2013/oct/04/nsa-gchq-attack-tor-network-encryption
 test_contains: The National Security Agency has made repeated attempts to develop


### PR DESCRIPTION
This PR removes stripping of figcaption tags for images and re-enables pruning of content.

This will, among other things, prune empty malformed figure tags (see https://github.com/j0k3r/php-readability/pull/66 for related info)