### PR TITLE
Updating body tags on kinja sites

### DIFF
--- a/avclub.com.txt
+++ b/avclub.com.txt
@@ -2,7 +2,7 @@
 
 title: //head/title
 author: //meta[@name="author"]/@content
-body: //div[contains(@class, 'post-content')]
+body: //div[contains(@class, 'js_post-content')]
 strip: //div[contains(@class, 'content-summary')]
 
 strip_id_or_class: magnifier

--- a/gizmodo.com.txt
+++ b/gizmodo.com.txt
@@ -1,6 +1,6 @@
 title: //head/title
 author: //meta[@name="author"]/@content
-body: //div[contains(@class, 'post-content')]
+body: //div[contains(@class, 'js_post-content')]
 strip: //div[contains(@class, 'content-summary')]
 
 strip_id_or_class: magnifier

--- a/jalopnik.com.txt
+++ b/jalopnik.com.txt
@@ -1,6 +1,6 @@
 title: //head/title
 author: //meta[@name="author"]/@content
-body: //div[contains(@class, 'post-content')]
+body: //div[contains(@class, 'js_post-content')]
 strip: //div[contains(@class, 'content-summary')]
 
 test_url: http://jalopnik.com/5892124/1955-porsche-550-spyder-sells-for-record-3685-million/

--- a/kotaku.com.txt
+++ b/kotaku.com.txt
@@ -1,6 +1,6 @@
 title: //head/title
 author: //meta[@name="author"]/@content
-body: //div[contains(@class, 'post-content')]
+body: //div[contains(@class, 'js_post-content')]
 strip: //div[contains(@class, 'content-summary')]
 
 test_url: https://kotaku.com/tumblr-porn-ban-leaves-artists-and-fans-seeking-new-pla-1831056412

--- a/lifehacker.com.txt
+++ b/lifehacker.com.txt
@@ -2,7 +2,7 @@
 
 title: //head/title
 author: //meta[@name="author"]/@content
-body: //div[contains(@class, 'post-content')]
+body: //div[contains(@class, 'js_post-content')]
 strip: //div[contains(@class, 'content-summary')]
 
 strip_id_or_class: magnifier

--- a/theinventory.com.txt
+++ b/theinventory.com.txt
@@ -2,7 +2,7 @@
 
 title: //head/title
 author: //meta[@name="author"]/@content
-body: //div[contains(@class, 'post-content')]
+body: //div[contains(@class, 'js_post-content')]
 strip: //div[contains(@class, 'content-summary')]
 
 strip: //aside

--- a/theonion.com.txt
+++ b/theonion.com.txt
@@ -1,6 +1,6 @@
 title: //head/title
 author: //meta[@name="author"]/@content
-body: //div[contains(@class, 'post-content')]
+body: //div[contains(@class, 'js_post-content')]
 strip: //div[contains(@class, 'content-summary')]
 
 test_url: https://www.theonion.com/theresa-may-narrowly-manages-to-survive-parliamentary-f-1831077604

--- a/theroot.com.txt
+++ b/theroot.com.txt
@@ -1,6 +1,6 @@
 title: //head/title
 author: //meta[@name="author"]/@content
-body: //div[contains(@class, 'post-content')]
+body: //div[contains(@class, 'js_post-content')]
 strip: //div[contains(@class, 'content-summary')]
 
 test_url: https://verysmartbrothas.theroot.com/trashcan-lannister-tweets-about-border-wall-gets-dunke-1831074232

--- a/thetakeout.com.txt
+++ b/thetakeout.com.txt
@@ -1,6 +1,6 @@
 title: //head/title
 author: //meta[@name="author"]/@content
-body: //div[contains(@class, 'post-content')]
+body: //div[contains(@class, 'js_post-content')]
 strip: //div[contains(@class, 'content-summary')]
 
 test_url: https://thetakeout.com/how-to-combat-boredom-in-the-suburbs-this-holiday-1831021448


### PR DESCRIPTION
The kinja sites updated their engine and now they tag their body content using "js_post-content" instead of just "post-content". This modifies the search pattern to look for the updated string.