### PR TITLE
Make the feed from cert-bund.de more useful

### DIFF
--- a/cert-bund.de.txt
+++ b/cert-bund.de.txt
@@ -1,0 +1,1 @@
+body:   //div[@class='announcement-top information']|//div[@class='announcement revisionhistory']|//div[@class='announcement description']

--- a/cert-bund.de.txt
+++ b/cert-bund.de.txt
@@ -1,3 +1,3 @@
-body:   //div[@class='announcement-top information']|//div[@class='announcement revisionhistory']|//div[@class='announcement description']
+body: //div[@class='announcement-top information']|//div[@class='announcement revisionhistory']|//div[@class='announcement description']
 
-test_url: http://www.cert-bund.de/advisoryshort/CB-K18-1118%20UPDATE%205
+test_url: https://www.cert-bund.de/advisoryshort/CB-K18-1118%20UPDATE%205

--- a/cert-bund.de.txt
+++ b/cert-bund.de.txt
@@ -1,1 +1,3 @@
 body:   //div[@class='announcement-top information']|//div[@class='announcement revisionhistory']|//div[@class='announcement description']
+
+test_url: http://www.cert-bund.de/advisoryshort/CB-K18-1118%20UPDATE%205


### PR DESCRIPTION
Now the feed displays more informations such as:
- revision history
- detailed table about the different values (CVE number, link, affected plattforms etc)
- description about the software which had a problem