### PR TITLE
modified diepresse.com

### DIFF
--- a/diepresse.com.txt
+++ b/diepresse.com.txt
@@ -46,4 +46,4 @@ replace_string: /images/
 
 test_url: http://diepresse.com/home/politik/aussenpolitik/701905/TibeterProteste_Nonne-verbrennt-sich-selbst?_vl_backlink=/home/politik/index.do
 test_url: https://www.diepresse.com/6115784/omikron-ba2-wann-infizierte-hoch-ansteckend-sind
-test_url: https://www.diepresse.com/rss/wien
+test_url: https://www.diepresse.com/rss/Wien

--- a/diepresse.com.txt
+++ b/diepresse.com.txt
@@ -1,17 +1,48 @@
+# choose your source feeds at
+# https://www.diepresse.com/105106/rss
+
 title: //div[@class='article']/h1
 date: substring-before(//p[@class='articletime'],'|')
 body: //div[@id='articletext']
 strip: //div[@class='inlineDiashow']
 
-# strip generic text images for articles without photos/images
+# Strip Parameter from Link in item-links of feed
+# just in case...
+
+find_string: ?from=rss
+replace_string:
+
+# strip gerneric text images when there is no article photo/image
+
 find_string: https://www.diepresse.com/assets_v2/images/
 replace_string:
 
-# replace image path to strip the text overlay on photos/images
+# 'data-src' sometimes prevents images to load, replaced with 'src'
+
+find_string: class="figure__image lazyload" data-src=
+replace_string: class="figure__image lazyload" src=
+
+#################
+# change path for images to get rid of the text overlays
+
+find_string: /social_diepresse_nachrichten_paid/images/
+replace_string: /images/
+
 find_string: /social_diepresse_nachrichten/images/
 replace_string: /images/
+
 find_string: /social_diepresse_magazin_paid/images/
 replace_string: /images/
+
+find_string: /social_diepresse_magazin/images/
+replace_string: /images/
+
+find_string: /social_diepresse_meinung_paid/images/
+replace_string: /images/
+
+find_string: /social_diepresse_meinung/images/
+replace_string: /images/
+#################
 
 test_url: http://diepresse.com/home/politik/aussenpolitik/701905/TibeterProteste_Nonne-verbrennt-sich-selbst?_vl_backlink=/home/politik/index.do
 test_url: https://www.diepresse.com/6115784/omikron-ba2-wann-infizierte-hoch-ansteckend-sind

--- a/diepresse.com.txt
+++ b/diepresse.com.txt
@@ -3,4 +3,15 @@ date: substring-before(//p[@class='articletime'],'|')
 body: //div[@id='articletext']
 strip: //div[@class='inlineDiashow']
 
+find_string: https://www.diepresse.com/assets_v2/images/
+replace_string:
+
+find_string: /social_diepresse_nachrichten/images/
+replace_string: /images/
+
+find_string: /social_diepresse_magazin_paid/images/
+replace_string: /images/
+
 test_url: http://diepresse.com/home/politik/aussenpolitik/701905/TibeterProteste_Nonne-verbrennt-sich-selbst?_vl_backlink=/home/politik/index.do
+test_url: https://www.diepresse.com/6115784/omikron-ba2-wann-infizierte-hoch-ansteckend-sind
+test_url: https://www.diepresse.com/rss/wien

--- a/diepresse.com.txt
+++ b/diepresse.com.txt
@@ -3,12 +3,13 @@ date: substring-before(//p[@class='articletime'],'|')
 body: //div[@id='articletext']
 strip: //div[@class='inlineDiashow']
 
+# strip generic text images for articles without photos/images
 find_string: https://www.diepresse.com/assets_v2/images/
 replace_string:
 
+# replace image path to strip the text overlay on photos/images
 find_string: /social_diepresse_nachrichten/images/
 replace_string: /images/
-
 find_string: /social_diepresse_magazin_paid/images/
 replace_string: /images/
 


### PR DESCRIPTION
- striped generic text images from og:image if there is no article photo. [Example](https://www.diepresse.com/6115882/mann-mit-schwert-loeste-polizeieinsatz-in-wien-simmering-aus)
- striped text overlays on pictures
- fix for empty pictures. [Example](https://www.diepresse.com/6110276/nobles-suv-mit-nicht-ganz-so-noblem-motor)