### PR TITLE
Shtrom 2022 04

### DIFF
--- a/.medium.com.txt
+++ b/.medium.com.txt
@@ -1,5 +1,7 @@
 # Copy changes between medium.com.txt and .medium.com.txt
 
+http_header(user-agent): Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)
+
 title: //meta[@property="og:title"]/@content
 title: //h1
 body: //article

--- a/cmns.umd.edu.txt
+++ b/cmns.umd.edu.txt
@@ -1,0 +1,6 @@
+title: //h1
+body: //div[@id='block-system-main']
+date: //span[@class='date-display-single']/@content
+
+test_url: https://cmns.umd.edu/news-events/features/4506
+test_contains: Internet censorship by authoritarian governments prohibits free and open access to information

--- a/medium.com.txt
+++ b/medium.com.txt
@@ -1,5 +1,7 @@
 # Copy changes between medium.com.txt and .medium.com.txt
 
+http_header(user-agent): Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)
+
 title: //meta[@property="og:title"]/@content
 title: //h1
 body: //article
@@ -11,6 +13,7 @@ strip: //button
 strip: //article//img[contains(@src, '?q=20') or contains(@src, 'max/34/')]
 # Remove empty images (width attribute but no src attribute)
 strip: //article//img[not(@src)]
+
 # Use the high-quality copies in <noscript> elements
 replace_string(<noscript>): <div class="ftr-noscript">
 replace_string(</noscript>): </div>

--- a/newyorker.com.txt
+++ b/newyorker.com.txt
@@ -19,6 +19,7 @@ strip_id_or_class: split-screen-content-header__rubric
 strip_id_or_class: split-screen-content-header__rubric-issue-date
 
 prune: no
+tidy: no
 
 test_url: https://www.newyorker.com/magazine/2016/02/08/mothers-day-fiction-george-saunders
 test_url: https://www.newyorker.com/online/blogs/culture/2012/06/mug-shot-web-sites.html


### PR DESCRIPTION
Fixes medium.com and introduces cmns.umd; tentative fix for newyorker, but not sufficient.