### PR TITLE
Add infolibre.es

### DIFF
--- a/infolibre.es.txt
+++ b/infolibre.es.txt
@@ -1,0 +1,7 @@
+requires_login: yes
+
+login_uri: https://usuarios.infolibre.es/iniciar-sesion/
+login_username_field: email
+login_password_field: password
+
+not_logged_in_xpath: //body[@class="not-logged-in"]


### PR DESCRIPTION
Adding the configuration file for infolibre.es, a Spanish digital newspaper, so Wallabag can fetch contents behind the paywall.