### PR TITLE
youtube: specify attribute where to find single page link

### DIFF
--- a/youtube.com.txt
+++ b/youtube.com.txt
@@ -14,7 +14,7 @@ replace_string: ></iframe>
 find_string: &quot;
 replace_string: '
 
-single_page_link: //link[@type='text/xml+oembed']
+single_page_link: //link[@type='text/xml+oembed']/@href
 
 # Correct User-Agent string needed to get the oembed URL
 http_header(user-agent): PHP/7.4


### PR DESCRIPTION
Just something I noticed:

The youtube config selects the whole link element:

```
single_page_link: //link[@type='text/xml+oembed']
```

```
<link rel="alternate" type="text/xml+oembed" href="https://www.youtube.com/oembed?format=xml&amp;url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DGjENnyQupow" title="Noam Chomsky on Propaganda - The Big Idea - Interview with Andrew Marr">
```

But as I understand selecting the `href` property would be more correct.

```
single_page_link: //link[@type='text/xml+oembed']/@href
```

Is there some kind of special handling for `single_page_link` rules in place that automatically looks up the `href` property when the node does not contain any content?