### PR TITLE
Fix fetching nytimes.com articles

### DIFF
--- a/nytimes.com.txt
+++ b/nytimes.com.txt
@@ -72,7 +72,7 @@ strip_id_or_class: NYT_MAIN_CONTENT_1_REGION
 strip_id_or_class: related-links-block
 strip_id_or_class: g-LABELS
 
-http_header(user-agent): PHP/7.4
+http_header(user-agent): curl/7.83.1
 
 prune: no
 tidy: no


### PR DESCRIPTION
The fix introduced by 5c96a669916e6174450d45d28650195bf65df1cb was incomplete

Fixes https://github.com/wallabag/wallabag/issues/5935