### PR TITLE
change to .wp.pl.txt

### DIFF
--- a/.wp.pl.txt
+++ b/.wp.pl.txt
@@ -1,9 +1,34 @@
 body: (//article)[1]
 
 strip: //*[contains(@class, 'subjectsList')]
-strip: //div[@data-st-area="article-header"]//*[contains(@class, 'article--title')]
 strip: //svg
+
+# sometimes header contains picture wuth text overlay (title, author, date)
+# first line eliminates complete header incl. photo
+# instead you can #comment this out and activate the following 3 strips
+# which left the date+time back in the body (ugly)
+strip: //div[@data-st-area="article-header"]
+#strip: //div[@data-st-area="article-header"]//*[contains(@class, 'article--title')]
+#strip: //div[@data-st-area="article-header"]//ul/li
+#strip: //div[@data-st-area="article-header"]//ul
+
+
+# strip adverts. Assuming class-length is allways the same: <div class="1234567 1234567"
+# this might be very unreliable
+strip: //div[string-length(@class) = 15]
+
+# strip article-title from body
+strip: //h1[contains(@class, 'article--title')]
+
+#strip twitter block
+strip: //blockquote[contains(@class, 'twitter-tweet')]
+
+# more cleanup
+strip: //button
+
 
 prune: no
 
 test_url: https://wiadomosci.wp.pl/spedzil-dwa-miesiace-w-podziemiach-azowstalu-mowili-ze-mozemy-jezdzic-po-calej-ukrainie-a-i-tak-nas-dopadna-6769475637812128a
+test_url: https://wiadomosci.wp.pl/zareczyny-polityka-960-m-pod-ziemia-tak-sie-bawi-wladza-pis-6854775542082464a
+test_url: https://wiadomosci.wp.pl/pieklo-pieklo-pieklo-jachira-uderza-w-pis-6854849794407328a

--- a/.wp.pl.txt
+++ b/.wp.pl.txt
@@ -8,9 +8,9 @@ strip: //svg
 # instead you can #comment this out and activate the following 3 strips
 # which left the date+time back in the body (ugly)
 strip: //div[@data-st-area="article-header"]
-#strip: //div[@data-st-area="article-header"]//*[contains(@class, 'article--title')]
-#strip: //div[@data-st-area="article-header"]//ul/li
-#strip: //div[@data-st-area="article-header"]//ul
+strip: //div[@data-st-area="article-header"]//*[contains(@class, 'article--title')]
+strip: //div[@data-st-area="article-header"]//ul/li
+strip: //div[@data-st-area="article-header"]//ul
 
 
 # strip adverts. Assuming class-length is allways the same: <div class="1234567 1234567"


### PR DESCRIPTION
- strip adverts by length of class-field in div-tag. Not reliable, i think
- remove complete header from body, which removed also sometimes included photos with text overlay. Otherwise I found no way to get rid of date and time in body text in those articles with image in header.
- strip more fringe