### PR TITLE
Update derstandard.at.txt

### DIFF
--- a/derstandard.at.txt
+++ b/derstandard.at.txt
@@ -27,6 +27,7 @@ strip: //p[@class='article-pubdate']
 strip: //aside[@data-type='supplemental']
 strip: //div[@class='article-byline']
 strip: //div[@class='article-meta']
+strip: //footer[starts-with(text(), 'Foto:')]
 
 http_header(Cookie): DSGVO_ZUSAGE_V1=true
 


### PR DESCRIPTION
strip photo source text, because some clients pushes first photo to the top of the article, which leaves the source text between the article text.
e.g. Fiery Feeds for iOS via FreshRSS
test_url: sec://www.derstandard.at/story/2000142907896/hafermilch-nicht-automatisch-die-gesuendere-alternative?ref=rss

![image](https://user-images.githubusercontent.com/3876469/214720452-64067abf-94b0-4fe3-9ef1-107681599123.png)
