### PR TITLE
Update thecut.com.txt

### DIFF
--- a/thecut.com.txt
+++ b/thecut.com.txt
@@ -3,6 +3,7 @@
 title: //h2[contains(@class, 'primary')]
 body: //*[@itemprop="articleBody"]
 body: //div[@id='story']
+body: //section[@class='body']
 author: //*[@class='by']/a
 date: substring-after(//*[@class='date'], 'Published')
 
@@ -11,6 +12,8 @@ http_header(Cookie): nymuc=11111111111
 
 parser: html5php
 tidy: no
+
+strip: //button
 
 next_page_link: //div[@class='page-navigation']//li[@class='next']/a
 


### PR DESCRIPTION
strip buttons

new body identifier. In some cases sub headings where not shown -> https://www.thecut.com/article/tipping-rules-etiquette-rules.html

as descibed here: https://forum.fivefilters.org/t/the-cut-article-sent-text-with-no-headings/1515/1