### PR TITLE
Fix for new optional article design

### DIFF
--- a/stadt-bremerhaven.de.txt
+++ b/stadt-bremerhaven.de.txt
@@ -7,6 +7,7 @@ strip: //img[contains(concat(" ", normalize-space(@class), " "), " jetpack-lazy-
 
 strip: //div[@class='aawp']
 strip_id_or_class: aawp-disclaimer
+strip_id_or_class: su-posts
 
 test_url: https://stadt-bremerhaven.de/google-meet-laesst-sich-nun-auf-alle-cast-faehigen-geraete-streamen/
 test_url: https://stadt-bremerhaven.de/nanoleaf-essentials-a60-mit-thread-im-test/


### PR DESCRIPTION
Some short articles may have several sections at the end with summaries of other articles that have nothing to do with the topic of the current article. This fix removes `div.su-posts`

e.g.:
https://stadt-bremerhaven.de/vanmoof-s5-a5-nun-in-dark-gray-erhaeltlich/
https://stadt-bremerhaven.de/update-dienstag-windows-10-und-windows-11-werden-beliefert/