### PR TITLE
Update stadt-bremerhaven.de.txt

### DIFF
--- a/stadt-bremerhaven.de.txt
+++ b/stadt-bremerhaven.de.txt
@@ -9,6 +9,8 @@ strip: //div[@class='aawp']
 strip_id_or_class: aawp-disclaimer
 strip_id_or_class: su-posts
 
+prune: no
+
 test_url: https://stadt-bremerhaven.de/google-meet-laesst-sich-nun-auf-alle-cast-faehigen-geraete-streamen/
 test_url: https://stadt-bremerhaven.de/nanoleaf-essentials-a60-mit-thread-im-test/
 test_url: https://stadt-bremerhaven.de/facebook-stellt-heute-wohl-noch-neue-audio-loesungen-vor/


### PR DESCRIPTION
added `prune: no` because pruning causes loss of dotted lists.

e.g.:
https://stadt-bremerhaven.de/playstation-store-neue-aktion-mit-bis-zu-75-rabatt-auf-unerlaesslische-favoriten/