### PR TITLE
Update stadt-bremerhaven.de.txt

### DIFF
--- a/stadt-bremerhaven.de.txt
+++ b/stadt-bremerhaven.de.txt
@@ -8,6 +8,7 @@ strip: //img[contains(concat(" ", normalize-space(@class), " "), " jetpack-lazy-
 strip: //div[@class='aawp']
 strip_id_or_class: aawp-disclaimer
 strip_id_or_class: su-posts
+strip_id_or_class: wp-embedded-content
 
 prune: no
 


### PR DESCRIPTION
site owner seems to be very busy the last days to change his layout. Striped another method of embedding article teasers of non-relevant articles.

e.g. https://stadt-bremerhaven.de/ekey-stellt-einige-produkte-ein/