### PR TITLE
heise.de: generalize expressions for stripping of teaser lists

### DIFF
--- a/heise.de.txt
+++ b/heise.de.txt
@@ -48,10 +48,7 @@ strip: //figure[@class='printversion__logo']
 strip: //figure[@class='branding']
 strip: //a-ad
 strip: //footer
-strip: //div/header/h3[contains(text(), 'Lesen Sie auch')]/ancestor::div
-strip: //div/header/h3[contains(text(), 'Weiter im Thema')]/ancestor::div
-strip: //div/header/h3[contains(text(), 'Mehr zum Thema')]/ancestor::div
-strip: //div/header/h3[contains(text(), 'Lesen Sie mehr zum Thema')]/ancestor::div
+strip: //div/section[@data-component='TeaserList']/ancestor::div
 
 
 strip_id_or_class: comments


### PR DESCRIPTION
This way stripping of teaser lists is independent of the headline text now. Hopefully this is more future-proof