### PR TITLE
heise: only strip first ancestor

### DIFF
--- a/heise.de.txt
+++ b/heise.de.txt
@@ -48,7 +48,7 @@ strip: //figure[@class='printversion__logo']
 strip: //figure[@class='branding']
 strip: //a-ad
 strip: //footer
-strip: //div/section[@data-component='TeaserList']/ancestor::div
+strip: //div/section[@data-component='TeaserList']/ancestor::div[1]
 
 
 strip_id_or_class: comments


### PR DESCRIPTION
I'm using libxml2 to process the `heise.de`  config. And libxml2 seems to match EVERY `<div>`  that is an ancestor of the matching `<section>` which in turn eliminates most of the html document.

Does Full-Text RSS do something to prevent this or would the same issue apply?