### PR TITLE
Update heise.de.txt

### DIFF
--- a/heise.de.txt
+++ b/heise.de.txt
@@ -87,6 +87,7 @@ replace_string(</a-img>): </img></div>
 strip: //div[@class="ff-a-img"]//img[not(@data-ff-replacement)]
 
 # Some optimizations
+replace_string(<h2 class="printversion__untertitel"></h2>):
 replace_string(<h5>): <h2>
 replace_string(</h5>): </h2>
 replace_string(<title>Druckversion - ): <title>


### PR DESCRIPTION
sometimes an empty h2-tag in print-version results in an unclosed h2 tag in wallabag, which makes the whole text large. I think it is because of the replacing of h5 to h2 which conflicts with the original h2 tags

e.g.
https://www.heise.de/tests/Kurztests-Desktop-Uebersetzer-Markdown-Notizbuch-und-Online-Whiteboard-9201345.html