### PR TITLE
Update derstandard.at.txt

### DIFF
--- a/derstandard.at.txt
+++ b/derstandard.at.txt
@@ -3,10 +3,11 @@
 
 title: //div[@id='content-header']/h1
 author: //div[@class='article-origins']
-body: //article[@class='story-article']
+body: //article[@class='story-article'] | //div[@id='A']
 
 strip_id_or_class: article-kicker
 strip_id_or_class: article-title
+strip_id_or_class: toolbar
 strip: //nav
 strip: //ul[@class='lookupLinksArtikel']
 
@@ -29,6 +30,9 @@ strip: //div[@class='article-byline']
 strip: //div[@class='article-meta']
 strip: //footer[starts-with(text(), 'Foto:')]
 
+find_string: 0 ? postingCount() : '' ">
+replace_string:
+
 http_header(Cookie): DSGVO_ZUSAGE_V1=true
 
 prune: no
@@ -36,6 +40,6 @@ tidy: no
 
 test_url: http://derstandard.at/rss
 test_url: http://derstandard.at/2000033602592/40-Jahre-fuer-einen-der-nicht-gemeinsam-leben-wollte
-test_url: http://derstandard.at/2000017141382/Feature-Format
 test_url: http://derstandard.at/2000031826169/Die-Mittagspause-ist-den-meisten-heilig
 test_url: http://derstandard.at/2000032076109/Fordern-wir-die-totale-Ueberwachung
+test_url: https://www.derstandard.at/jetzt/livebericht/2000135273905/uno-generalsekretaer-guterres-trifft-in-kiew-und-am-donnerstag-selenskyj?responsive=false


### PR DESCRIPTION
Support for ticker messages. Only the summary in the left column is taken. The actual live ticker is reloaded by script and cannot be saved.
e.g.: https://www.derstandard.at/jetzt/livebericht/2000135273905/uno-generalsekretaer-guterres-trifft-in-kiew-und-am-donnerstag-selenskyj

should fix https://github.com/wallabag/wallabag/issues/5760