### PR TITLE
Update polygon.com.txt

### DIFF
--- a/polygon.com.txt
+++ b/polygon.com.txt
@@ -1,4 +1,5 @@
 body: //div[contains(@class='c-entry-content')]
+body: //article[@id='entry-top']/div/section[1]
 author: //div[contains(@class, 'c-entry-hero')]//a[contains(@href, 'https://www.polygon.com/authors/')]
 
 prune: no
@@ -7,6 +8,9 @@ find_string: <noscript>
 replace_string: <div>
 find_string: </noscript>
 replace_string: </div>
+
+strip: //label
+strip_id_or_class: toc
 
 # right floating quotes are incorrectly inserted into paragraphs
 replace_string(<q class="right"): <q class="center"


### PR DESCRIPTION
1. Fixed: last patch broke test_url 2 for at least FulltextRSS (FTR).

2. http://www.polygon.com/features/2013/8/22/4602568/30-years-xbox-360-playstation-3-wii
contains some pair/tripple images in the timeline which are animated by script during scrolling the webpage in browser. Neither FTR nor Wallabeg can rebuild that, so I left all pictures in, because no one could say which one is the important one for all articles in ths scheme.