### PR TITLE
Update arretsurimages.net.txt

### DIFF
--- a/arretsurimages.net.txt
+++ b/arretsurimages.net.txt
@@ -5,6 +5,7 @@ body: //div[contains(concat(' ',normalize-space(@class),' '),' article-body ')]
 http_header(User-Agent): Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
 
 strip: //aside
+strip: //svg[@tooltip=""]
 
 strip_id_or_class: mobile-only
 strip_id_or_class: article-header


### PR DESCRIPTION
fix for FTR. There is a play-image-overlay on the still imagage of the article which starts a video on orginal site, but not on FTR or wallabag. In FTR this `<svg>` was enlarged and seperated from the still image.

e.g. https://www.arretsurimages.net/chroniques/la-vie-du-site/foire-aux-questions-pour-arret-sur-images

![grafik](https://github.com/fivefilters/ftr-site-config/assets/3876469/89a7621a-9867-4d4d-b0ee-a25ac00603fe)
