### PR TITLE
Fix getting full text, similar to nytimes.com

### DIFF
--- a/seattletimes.com.txt
+++ b/seattletimes.com.txt
@@ -2,5 +2,7 @@ body: //div[@id="article-content"]
 
 strip_id_or_class: ad-container
 
+http_header(user-agent): curl/7.83.1
+
 test_url: https://www.seattletimes.com/nation-world/nation/ex-cia-engineer-tells-judge-hes-incarcerated-like-an-animal/
 test_contains: horrified by the conditions in which he has to live daily


### PR DESCRIPTION
Currently, seattletimes.com is broken. The user agent fix for nytimes.com worked, so this is a pull to bring that over to seattletimes.com. Thanks.