### PR TITLE
Medium.com

### DIFF
--- a/.medium.com.txt
+++ b/.medium.com.txt
@@ -55,6 +55,16 @@ prune: no
 #find_string: .gif 640w
 #replace_string: .gif"><foo bar="
 
+### VERY BRAVE self-hosters may try to acticate this block INSTEAD
+### helps to show also images with no filename extension.
+#find_string: source srcSet="http
+#replace_string: img src="http
+#find_string: source srcset="http
+#replace_string: img src="http
+#replace_string( 1400w,): "><foo bar="
+#replace_string( 720w,): "><foo bar="
+#replace_string( 640w,): "><foo bar="
+
 test_url: https://dougshapiro.medium.com/how-will-the-disruption-of-hollywood-play-out-42f724c921e1
 test_contains: you consider the costs for talent
 test_url: https://elemental.medium.com/the-dark-side-of-fitness-tracking-9b218989bc47

--- a/medium.com.txt
+++ b/medium.com.txt
@@ -1,5 +1,3 @@
-# Copy changes between medium.com.txt and .medium.com.txt
-
 # website-engine: medium.com
 http_header(user-agent): Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)
 
@@ -56,6 +54,16 @@ prune: no
 #replace_string: .jpeg"><foo bar="
 #find_string: .gif 640w
 #replace_string: .gif"><foo bar="
+
+### VERY BRAVE self-hosters may try to acticate this block INSTEAD
+### helps to show also images with no filename extension.
+#find_string: source srcSet="http
+#replace_string: img src="http
+#find_string: source srcset="http
+#replace_string: img src="http
+#replace_string( 1400w,): "><foo bar="
+#replace_string( 720w,): "><foo bar="
+#replace_string( 640w,): "><foo bar="
 
 test_url: https://medium.com/@savolai/kaytettavyyden-haasteet-keskustelukulttuurista-2-3-6844c0d7893b
 test_contains: Jos käytettävyysongelmat ovat kerran niin tyypillisiä


### PR DESCRIPTION
added an inactive block for self-hosters.

@j0k3r: The following issues were already fixed with the last update and can be closed. I just checked the links in the issues again with Wallbag 2.6.2 and FTR 3.9.13

* fixes https://github.com/wallabag/wallabag/issues/6735
* fixes https://github.com/wallabag/wallabag/issues/6734
* fixes https://github.com/wallabag/wallabag/issues/6733
* fixes https://github.com/wallabag/wallabag/issues/6732
* fixes https://github.com/wallabag/wallabag/issues/5663
* fixes https://github.com/wallabag/wallabag/issues/5543
* fixes https://github.com/wallabag/wallabag/issues/5389


