### PR TITLE
Updates 56 sites off ippen.media

### DIFF
--- a/24auto.de.txt
+++ b/24auto.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.24auto.de/news/adac-panne-elektro-auto-starterbatterie-akku-wachstum-verbrenner-tuev-wartung-muenchen-starthilfe-91426845.html

--- a/24garten.de.txt
+++ b/24garten.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.24garten.de/mein-garten/basilikum-trocknen-einlegen-haltbarkeit-ernte-kraeuter-pesto-einfrieren-rosmarin-muenchen-zr-91424291.html

--- a/24hamburg.de.txt
+++ b/24hamburg.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.24hamburg.de/hamburg/neue-corona-regeln-im-hvv-ab-sofort-entfaellt-3g-91422638.html

--- a/24rhein.de.txt
+++ b/24rhein.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.24rhein.de/koeln/kalk/koeln-videoueberwachung-kameras-kalk-orte-ueberblick-polizei-ausbau-91388746.html

--- a/24vita.de.txt
+++ b/24vita.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.24vita.de/verbraucher/allesesser-vegetarier-veganer-deutschland-daab-fleisch-herstellung-speiseplan-dge-bonn-91417014.html

--- a/az-online.de.txt
+++ b/az-online.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.az-online.de/uelzen/stadt-uelzen/mehr-gaeste-in-der-uelzener-stadthalle-als-erlaubt-91282522.html

--- a/bgland24.de.txt
+++ b/bgland24.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.bgland24.de/bgland/region-berchtesgaden/bischofswiesen-ort28409/schoenau-am-koenigssee-wieder-grosses-interesse-bei-fit-durch-unser-gmoa-2022-91285772.html

--- a/buzzfeed.de.txt
+++ b/buzzfeed.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.buzzfeed.de/buzz/19-buecher-die-leute-einfach-nicht-zu-ende-lesen-konnten-91400849.html

--- a/bw24.de.txt
+++ b/bw24.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.bw24.de/baden-wuerttemberg/wolf-baden-wuerttemberg-sichtung-zollernalbkreis-spaziergaengerin-raubtier-nachweis-91297558.html

--- a/chiemgau24.de.txt
+++ b/chiemgau24.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.chiemgau24.de/chiemgau/chiemsee/gstadt-am-chiemsee-ort118608/gstadt-tourist-info-leiterin-berichtet-von-guter-auslastung-bei-gaestezahlen-trotz-corona-91288990.html

--- a/come-on.de.txt
+++ b/come-on.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.come-on.de/kreis-mk/corona-mk-zahlen-omikron-heute-inzidenz-tote-todesfall-news-aktuell-luedenscheid-iserlohn-ticker-91403642.html

--- a/costanachrichten.com.txt
+++ b/costanachrichten.com.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.costanachrichten.com/spanien/politik-wirtschaft/spanien-westsahara-pedro-sanchez-unabhaengigkeit-uno-marokko-fluechtlinge-ukraine-91422126.html

--- a/dasgelbeblatt.de.txt
+++ b/dasgelbeblatt.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.dasgelbeblatt.de/lokales/bad-toelz-wolfratshausen/landkreis-bad-toelz-wolfratshausen-prozent-mehr-gewaltstraftaten-in-2021-91426756.html

--- a/deichstube.de.txt
+++ b/deichstube.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.deichstube.de/news/werder-bremen-trotzt-problemen-was-der-sieg-gegen-sv-darmstadt-98-alles-aussagt-trainer-ole-werner-2-bundesliga-aufstieg-zr-91423406.html

--- a/echo24.de.txt
+++ b/echo24.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.echo24.de/baden-wuerttemberg/corona-verordnung-baden-wuerttemberg-regeln-kretschmann-maskenpflicht-lockerungen-zr-91419449.html

--- a/extratipp.com.txt
+++ b/extratipp.com.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.extratipp.com/tv/dsds/quoten-desaster-bei-dsds-setzt-rtl-die-castingshow-mit-florian-silbereisen-ab-91270865.html?trafficsource=idTopBox

--- a/fehmarn24.de.txt
+++ b/fehmarn24.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.fehmarn24.de/heiligenhafen/es-bleibt-das-grosse-ziel-die-innenstadt-von-heiligenhafen-soll-in-den-kommenden-jahren-attraktiver-werden-91421037.html

--- a/fnp.de.txt
+++ b/fnp.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.fnp.de/frankfurt/frankfurt-sachsenhausen-der-adlhochplatz-bekommt-einen-neuen-namen-91287869.html

--- a/fr.de.txt
+++ b/fr.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.fr.de/frankfurt/die-nfl-kommt-nach-frankfurt-91329620.html

--- a/fuldaerzeitung.de.txt
+++ b/fuldaerzeitung.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.fuldaerzeitung.de/fulda/corona-fulda-rki-inzidenz-neuinfektionen-impfung-novavax-klinikum-91368571.html

--- a/giessener-allgemeine.de.txt
+++ b/giessener-allgemeine.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.giessener-allgemeine.de/giessen/zwei-kuenstlerpositionen-vereint-91421463.html

--- a/hallo-muenchen.de.txt
+++ b/hallo-muenchen.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.hallo-muenchen.de/muenchen/mitte/muenchen-sitzsteine-stachus-brunnen-corona-abstand-polizei-treffpunkt-maerz-mai-91420320.html

--- a/hanauer.de.txt
+++ b/hanauer.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.hanauer.de/hanau/hanauer-gericht-sieht-nackte-tatsachen-nach-misslungener-polizeiaktion-91420845.html

--- a/heidelberg24.de.txt
+++ b/heidelberg24.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.heidelberg24.de/heidelberg/schlaegerei-heidelberg-altstadt-opfer-untere-strasse-polizei-einsatz-91425471.html

--- a/hersfelder-zeitung.de.txt
+++ b/hersfelder-zeitung.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.hersfelder-zeitung.de/lokales/philippsthal-heringen/philippsthal-ort473874/alpaka-hengst-cosmo-tot-aufgefunden-91425061.html

--- a/hna.de.txt
+++ b/hna.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.hna.de/kassel/eigentuemer-sollen-sich-ruesten-91290102.html

--- a/in-muenchen.de.txt
+++ b/in-muenchen.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.in-muenchen.de/theater/75-jahre-kleines-spiel-marionettentheater-fuer-erwachsene-in-muenchen-91228706.html

--- a/ingame.de.txt
+++ b/ingame.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.ingame.de/news/the-witcher-4-enthuellt-teaser-cd-projekt-red-release-offen-fans-konsolen-warschau-91426909.html

--- a/innsalzach24.de.txt
+++ b/innsalzach24.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.innsalzach24.de/innsalzach/holzland/toeging-am-inn-ort61987/toeging-inn-nistkaesten-fuer-mauersegler-am-rathausturm-91426965.html

--- a/kreis-anzeiger.de.txt
+++ b/kreis-anzeiger.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.kreis-anzeiger.de/lokales/wetteraukreis/mit-hoher-sicherheit-ein-wolf-91287739.html

--- a/kreisbote.de.txt
+++ b/kreisbote.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.kreisbote.de/lokales/landsberg/meldeverzuege-am-wochenende-90848517.html?trafficsource=idTopBox

--- a/kreiszeitung.de.txt
+++ b/kreiszeitung.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.kreiszeitung.de/lokales/bremen/bremen-wie-sich-osterholz-tenever-veraendert-hat-91304118.html

--- a/kurierverlag.de.txt
+++ b/kurierverlag.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.kurierverlag.de/bayern/razzien-gegen-hasskriminalitaet-17-beschuldigte-in-bayern-zr-91426730.html

--- a/leinetal24.de.txt
+++ b/leinetal24.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.leinetal24.de/lokales/hildesheim/polizeiinspektion-hildesheim-informiert-ueber-die-aktuelle-kriminalstatistik-91420438.html

--- a/lokalo24.de.txt
+++ b/lokalo24.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.lokalo24.de/lokales/fulda/ab-montag-neue-besucherregelungen-am-klinikum-fulda-91424837.html

--- a/ludwigshafen24.de.txt
+++ b/ludwigshafen24.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.ludwigshafen24.de/ludwigshafen/abfahrt-heinigstrasse-pruefung-monitoring-bruecke-hochstrasse-nord-auto-ludwigshafen-verkehr-91264126.html

--- a/mangfall24.de.txt
+++ b/mangfall24.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.mangfall24.de/bayern/hozkirchen-boff-im-foolskino-91427134.html

--- a/mannheim24.de.txt
+++ b/mannheim24.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.mannheim24.de/mannheim/quadrate-fressgasse-fussgaengerzone-verkehrsversuch-facebook-kommentare-mannheim-91412006.html

--- a/meine-anzeigenzeitung.de.txt
+++ b/meine-anzeigenzeitung.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.meine-anzeigenzeitung.de/bayern/corona-inzidenz-in-bayern-steigt-weiter-zr-91426750.html

--- a/merkur.de.txt
+++ b/merkur.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.merkur.de/politik/ukraine-krieg-russland-putin-hyperschall-raketen-kinschal-video-twitter-fake-experten-91427019.html

--- a/news.bayern.txt
+++ b/news.bayern.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.news.bayern/nullsupermarkt-hamsterkaeufe-oel-mehl-nuernberg-zettel-notes-of-germany-frust-ukraine-mkr-91426735.html

--- a/oktoberfest.bayern.txt
+++ b/oktoberfest.bayern.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.oktoberfest.bayern/wiesn/oktoberfest-2020-coronavirus-riesenrad-chef-ueber-wiesn-absage-ein-trauerspiel-zr-13717682.html

--- a/op-online.de.txt
+++ b/op-online.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.op-online.de/region/neu-isenburg/einige-strassenbauarbeiten-in-neu-isenburg-91412589.html

--- a/ovb-online.de.txt
+++ b/ovb-online.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.ovb-online.de/rosenheim/chiemgau/prien-am-chiemsee-kampfjet-tornado-im-tiefflug-ueber-dem-chiemsee-angst-war-natuerlich-gleich-da-91414102.html

--- a/rga.de.txt
+++ b/rga.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.rga.de/lokales/remscheid/corona-in-remscheid-maskenpflicht-im-rathaus-bleibt-91406940.html

--- a/rosenheim24.de.txt
+++ b/rosenheim24.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.rosenheim24.de/rosenheim/rosenheim-land/rosenheim-corona-zahlen-explodieren-viele-corona-tote-patienten-91420512.html

--- a/ruhr24.de.txt
+++ b/ruhr24.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.ruhr24.de/dortmund/wolfssichtung-deutschland-ruhrgebiet-wolfswelpe-maerz-2022-video-wolf-dortmund-nrw-eving-woelfe-91410695.html

--- a/sauerlandkurier.de.txt
+++ b/sauerlandkurier.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.sauerlandkurier.de/hochsauerlandkreis/corona-hsk-inzidenz-zahlen-test-impfung-schulen-news-heute-22-03-2022-aktuell-arnsberg-91424574.html

--- a/soester-anzeiger.de.txt
+++ b/soester-anzeiger.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.soester-anzeiger.de/lokales/kreis-soest/corona-virus-kreis-soest-inzidenz-booster-omikron-nrw-heute-dienstag-22-03-2022-daten-aktuell-regeln-zahlen-impfen-news-ticker-tot-impf-stoff-91372172.html

--- a/solinger-tageblatt.de.txt
+++ b/solinger-tageblatt.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.solinger-tageblatt.de/solingen/corona-in-solingen-vermehrt-vierte-impfung-in-arztpraxen-91406963.html

--- a/tz.de.txt
+++ b/tz.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.tz.de/muenchen/stadt/meunchen-sirenen-wegen-krieg-in-der-ukraine-neue-debatte-um-sirenen-in-muenchen-wie-warnt-die-stadt-im-ernstfall-zr-91423000.html

--- a/wa.de.txt
+++ b/wa.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.wa.de/hamm/stadt-hamm-setzt-wollring-gegen-eichenprozessionsspinner-ein-91414576.html

--- a/wasserburg24.de.txt
+++ b/wasserburg24.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.wasserburg24.de/bayern/landkreis-berchtesgadener-land/berchtesgaden-naturschuetzer-stellen-sich-gegen-fussweg-bei-baustelle-91427485.html

--- a/werra-rundschau.de.txt
+++ b/werra-rundschau.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.werra-rundschau.de/eschwege/corona-im-werra-meissner-kreis-sieben-tage-inzidenz-liegt-bei-1565-91404363.html

--- a/wetterauer-zeitung.de.txt
+++ b/wetterauer-zeitung.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.wetterauer-zeitung.de/wetterau/mahnwache-fuers-impfen-91318413.html

--- a/wlz-online.de.txt
+++ b/wlz-online.de.txt
@@ -1,12 +1,27 @@
-# Author: HolgerAusB  |  Version: 2022-03-22
+# Author: HolgerAusB  |  Version: 2023-08-17
 #
 # to get a source-feed, try to add 'rssfeed.rdf' to the category-URL e.g.
 #    https://www.example.com/hessen/rssfeed.rdf
 #
+# @ippen.media site
 #==========================
 
-# strip author box and social media box
-# these boxes sometimes prevented main picure to show up
+body: //article
+author: substring-after(//p[contains(@class, 'id-Story-authors')] , 'on:')
+author: //div[contains(@class, 'id-AuthorList')]/descendant::*[contains(@class, 'id-Link')]
+date: //p[contains(@class, 'id-Story-timestamp')]/descendant::time/@datetime
+
+strip_id_or_class: id-Article-dateActionboxCombo
+strip_id_or_class: id-Article-kicker
+strip_id_or_class: id-Article-headline
+strip_id_or_class: id-AuthorList
+strip_id_or_class: id-StoryElement-inArticleReco
+strip_id_or_class: id-Comments
+strip_id_or_class: id-Story-timestamp
+strip_id_or_class: id-Story-authors
+strip_id_or_class: id-Story-interactionBar
+strip: //a[@title='Bilderzoom']
+
 strip_id_or_class: idjs-simpletab-nav-item
 strip_id_or_class: idjs-simpletab-content-close
 strip_id_or_class: id-AuthorList
@@ -27,7 +42,6 @@ strip_id_or_class: id-Article-content-item.id-Article-advert
 strip_id_or_class: id-Article-advert--ad3
 strip_id_or_class: id-Article-advert
 
-tidy: yes
-prune: yes
-
+tidy: no
+prune: no
 test_url: https://www.wlz-online.de/frankenberg/corona-impfpflicht-einrichtungen-in-waldeck-frankenberg-muessen-mitarbeiter-dem-kreis-melden-91426968.html


### PR DESCRIPTION
* reflect slight design-changes of the ippen.media engine
* now supporting author and date selectors
* better image handling
* should now better work with wallabag

I copied my template by script. So all 56 files are identical except for the `test_url` in the last line