### PR TITLE
Update nzz.ch.txt (wallabag fix)

### DIFF
--- a/nzz.ch.txt
+++ b/nzz.ch.txt
@@ -10,5 +10,6 @@ strip: //div[@id='social-media-floater']
 strip: //div[@class='advertisement']
 strip: //div[@class='infobox']
 strip: //div[@id='articleComments']
+strip: //section[@componenttype='moreToSubject']
 
 test_url: https://www.nzz.ch/zuerich/gender-sprache-an-hochschulen-in-zuerich-drohen-punkteabzuege-ld.1679640


### PR DESCRIPTION
sorry, but this additional fix is needed for wallabag to prevent the text 'Passend zum Artikel' (related articles) at the end of content.