### PR TITLE
Add utcc.utoronto.ca.txt

### DIFF
--- a/utcc.utoronto.ca.txt
+++ b/utcc.utoronto.ca.txt
@@ -1,0 +1,5 @@
+http_header(referer): https://utcc.utoronto.ca/~cks/space/blog/
+
+title: //div[@class='wikitext titlehack']
+
+test_url: https://utcc.utoronto.ca/~cks/space/blog/web/BasicAuthAndURLHierarchy


### PR DESCRIPTION
Site is blocked without referer header. Set correct title as well.