### PR TITLE
Dazelddigital.com 2

### DIFF
--- a/dazeddigital.com.txt
+++ b/dazeddigital.com.txt
@@ -1,10 +1,9 @@
-# FTR works including images
-# wallabag works WITHOUT images, due to hardcoded autostrip of textless <span>
-
 body: (//article[@class='main-article'])[1]
 title: normalize-space( //meta[@property='og:title']/@content )
 author: //a[@class='contributor-name']
 date: //time[@class='timestamp']/@datetime
+
+wrap_in('<section>'): //h2
 
 strip: //aside
 strip: //h1[@class='title']
@@ -19,7 +18,11 @@ strip_id_or_class: hidden-desktop
 find_string: data-src="https://www.youtube.com/embed/
 replace_string: src="https://www.youtube.com/embed/
 
+find_string: <figure class="inline-img
+replace_string: <img class="inline-img
+
 prune: no
+tidy: no
 
 test_url: https://www.dazeddigital.com/beauty/article/60860/1/we-were-never-supposed-to-see-our-faces-this-much-social-media-zoom
 test_url: https://www.dazeddigital.com/beauty/article/60926/1/why-the-70s-cool-girl-beauty-of-dazed-and-confused-still-resonates-today

--- a/dazeddigital.com.txt
+++ b/dazeddigital.com.txt
@@ -3,8 +3,6 @@ title: normalize-space( //meta[@property='og:title']/@content )
 author: //a[@class='contributor-name']
 date: //time[@class='timestamp']/@datetime
 
-wrap_in('<section>'): //h2
-
 strip: //aside
 strip: //h1[@class='title']
 


### PR DESCRIPTION
- finally managed to show inline images in wallabag (with UI), see 2nd test_url
- lead image still missing in wallabag :-( due to span stripping