### PR TITLE
changed 1 and added 10 newspaper sites of German VRM group

### DIFF
--- a/allgemeine-zeitung.de.txt
+++ b/allgemeine-zeitung.de.txt
@@ -1,4 +1,4 @@
-# test_url: http://...# chose your source feed from:
+# chose your source feed from:
 # https://www.allgemeine-zeitung.de/rss/
 
 # site has paywall, if you are using wallabag try to use
@@ -40,6 +40,9 @@ prune: no
 
 # wallabag only:
 wrap_in(blockquote): //div[contains(@class, 'quoteWrapper')]
+# prevents wallabag to show image galery as overlay above article text
+find_string: class="contentWrapper slider
+replace_string: class="contentWrapper foo
 
 # don't remove this line! Site belongs to de_VRM group
 

--- a/allgemeine-zeitung.de.txt
+++ b/allgemeine-zeitung.de.txt
@@ -1,0 +1,51 @@
+# test_url: http://...# chose your source feed from:
+# https://www.allgemeine-zeitung.de/rss/
+
+# site has paywall, if you are using wallabag try to use
+# wallabagger browser-plugin with activated option
+# 'Retrieve content from the browser' in it's settings
+
+http_header(User-Agent): Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
+http_header(referer): https://www.echo-online.de/
+
+body: //article
+author: //meta[@name='twitter:creator']/@content
+title: normalize-space(//meta[@property='og:title']/@content)
+date: //time/@datetime
+
+strip: //path
+strip: //script
+strip: //footer
+strip: //div[contains(@class, 'recommendations')]
+strip: //div[@data-testid='storyline-intro-authors']
+strip: //aside[contains(@data-testid, 'linkbox')]
+strip: //svg
+
+strip_id_or_class: recommendations__topStories
+strip_id_or_class: recommendations__cceWidget
+strip_id_or_class: storyElementWrapper__paywallContainer
+strip_id_or_class: storylineIntro__dateAndReadingTime
+strip_id_or_class: loadingBanner
+strip_id_or_class: adSlot
+strip_id_or_class: storylineHeader
+
+replace_string(,"value":): ,"invalid":
+replace_string(,"storylineText":): ,"value":
+
+# prevent the site logo to show, if article has no image
+insert_detected_image: no
+
+tidy: no
+prune: no
+
+# wallabag only:
+wrap_in(blockquote): //div[contains(@class, 'quoteWrapper')]
+
+# don't remove this line! Site belongs to de_VRM group
+
+# The first URL will at some point no longer show 
+# the full article. There is a time-based paywall 
+# Using the feed should present valid output
+
+#test_url: https://www.allgemeine-zeitung.de/lokales/rheinhessen/zum-start-der-herbstferien-vollsperrung-der-l426-ab-montag-2937196
+test_url: https://www.allgemeine-zeitung.de/rss/

--- a/allgemeine-zeitung.de.txt
+++ b/allgemeine-zeitung.de.txt
@@ -48,4 +48,4 @@ wrap_in(blockquote): //div[contains(@class, 'quoteWrapper')]
 # Using the feed should present valid output
 
 #test_url: https://www.allgemeine-zeitung.de/lokales/rheinhessen/zum-start-der-herbstferien-vollsperrung-der-l426-ab-montag-2937196
-test_url: https://www.allgemeine-zeitung.de/rss/
+test_url: https://www.allgemeine-zeitung.de/rss/lokales/hessen/

--- a/buerstaedter-zeitung.de.txt
+++ b/buerstaedter-zeitung.de.txt
@@ -1,4 +1,4 @@
-# test_url: http://...# chose your source feed from:
+# chose your source feed from:
 # https://www.buerstaedter-zeitung.de/rss/
 
 # site has paywall, if you are using wallabag try to use
@@ -40,6 +40,9 @@ prune: no
 
 # wallabag only:
 wrap_in(blockquote): //div[contains(@class, 'quoteWrapper')]
+# prevents wallabag to show image galery as overlay above article text
+find_string: class="contentWrapper slider
+replace_string: class="contentWrapper foo
 
 # don't remove this line! Site belongs to de_VRM group
 

--- a/buerstaedter-zeitung.de.txt
+++ b/buerstaedter-zeitung.de.txt
@@ -1,0 +1,51 @@
+# test_url: http://...# chose your source feed from:
+# https://www.buerstaedter-zeitung.de/rss/
+
+# site has paywall, if you are using wallabag try to use
+# wallabagger browser-plugin with activated option
+# 'Retrieve content from the browser' in it's settings
+
+http_header(User-Agent): Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
+http_header(referer): https://www.echo-online.de/
+
+body: //article
+author: //meta[@name='twitter:creator']/@content
+title: normalize-space(//meta[@property='og:title']/@content)
+date: //time/@datetime
+
+strip: //path
+strip: //script
+strip: //footer
+strip: //div[contains(@class, 'recommendations')]
+strip: //div[@data-testid='storyline-intro-authors']
+strip: //aside[contains(@data-testid, 'linkbox')]
+strip: //svg
+
+strip_id_or_class: recommendations__topStories
+strip_id_or_class: recommendations__cceWidget
+strip_id_or_class: storyElementWrapper__paywallContainer
+strip_id_or_class: storylineIntro__dateAndReadingTime
+strip_id_or_class: loadingBanner
+strip_id_or_class: adSlot
+strip_id_or_class: storylineHeader
+
+replace_string(,"value":): ,"invalid":
+replace_string(,"storylineText":): ,"value":
+
+# prevent the site logo to show, if article has no image
+insert_detected_image: no
+
+tidy: no
+prune: no
+
+# wallabag only:
+wrap_in(blockquote): //div[contains(@class, 'quoteWrapper')]
+
+# don't remove this line! Site belongs to de_VRM group
+
+# The first URL will at some point no longer show 
+# the full article. There is a time-based paywall 
+# Using the feed should present valid output
+
+#test_url: https://www.buerstaedter-zeitung.de/lokales/hessen/trotz-demoverbots-anti-israelische-proteste-in-frankfurt-2943654
+test_url: https://www.buerstaedter-zeitung.de/rss/lokales/hessen/

--- a/echo-online.de.txt
+++ b/echo-online.de.txt
@@ -40,6 +40,9 @@ prune: no
 
 # wallabag only:
 wrap_in(blockquote): //div[contains(@class, 'quoteWrapper')]
+# prevents wallabag to show image galery as overlay above article text
+find_string: class="contentWrapper slider
+replace_string: class="contentWrapper foo
 
 # don't remove this line! Site belongs to de_VRM group
 

--- a/echo-online.de.txt
+++ b/echo-online.de.txt
@@ -1,9 +1,12 @@
 # chose your source feed from:
 # https://www.echo-online.de/rss/
 
+# site has paywall, if you are using wallabag try to use
+# wallabagger browser-plugin with activated option
+# 'Retrieve content from the browser' in it's settings
+
 http_header(User-Agent): Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
 http_header(referer): https://www.echo-online.de/
-
 
 body: //article
 author: //meta[@name='twitter:creator']/@content

--- a/echo-online.de.txt
+++ b/echo-online.de.txt
@@ -41,6 +41,8 @@ prune: no
 # wallabag only:
 wrap_in(blockquote): //div[contains(@class, 'quoteWrapper')]
 
+# don't remove this line! Site belongs to de_VRM group
+
 # The first URL will at some point no longer show 
 # the full article. There is a time-based paywall 
 # Using the feed should present valid output

--- a/echo-online.de.txt
+++ b/echo-online.de.txt
@@ -1,25 +1,46 @@
-# Author: Marvin Dickhaus
-# 2014-10-08
+# chose your source feed from:
+# https://www.echo-online.de/rss/
 
-#Tidy just messes up the DOM
+http_header(User-Agent): Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
+http_header(referer): https://www.echo-online.de/
+
+
+body: //article
+author: //meta[@name='twitter:creator']/@content
+title: normalize-space(//meta[@property='og:title']/@content)
+date: //time/@datetime
+
+strip: //path
+strip: //script
+strip: //footer
+strip: //div[contains(@class, 'recommendations')]
+strip: //div[@data-testid='storyline-intro-authors']
+strip: //aside[contains(@data-testid, 'linkbox')]
+strip: //svg
+
+strip_id_or_class: recommendations__topStories
+strip_id_or_class: recommendations__cceWidget
+strip_id_or_class: storyElementWrapper__paywallContainer
+strip_id_or_class: storylineIntro__dateAndReadingTime
+strip_id_or_class: loadingBanner
+strip_id_or_class: adSlot
+strip_id_or_class: storylineHeader
+
+replace_string(,"value":): ,"invalid":
+replace_string(,"storylineText":): ,"value":
+
+# prevent the 'echo' logo to show, if article has no image
+insert_detected_image: no
+
 tidy: no
+prune: no
 
-title: //h1
-body: //h2 | //div[@id='artikelteaser'] | //div[@id='artikeltext']
+# wallabag only:
+wrap_in(blockquote): //div[contains(@class, 'quoteWrapper')]
 
-#Strip 
-strip_image_src: artikel_a_merken.gif
-strip: //div[@class='zusatzinfo']
+# The first URL will at some point no longer show 
+# the full article. There is a time-based paywall 
+# Using the feed should present valid output
 
-#Author: substring is used to remove the " Von " prefix.
-author: substring(//li[@class='artikelautor'], 5)
-
-date: //li[@class='artikeldatum']
-
-#The first two URLs will at some point no longer show 
-#the full article. There is a time-based paywall 
-#installed. Using the feed should present valid output
-#test_url: http://www.echo-online.de/art1231,5503063
-#test_url: http://www.echo-online.de/art1168,5502598
-test_url: http://www.echo-online.de/lokales/darmstadt/index.rss
-
+#test_url: https://www.echo-online.de/lokales/darmstadt/austausch-fuer-psychisch-erkrankte-in-darmstadt-2945125
+test_url: https://www.echo-online.de/rss/lokales/darmstadt/

--- a/echo-online.de.txt
+++ b/echo-online.de.txt
@@ -32,7 +32,7 @@ strip_id_or_class: storylineHeader
 replace_string(,"value":): ,"invalid":
 replace_string(,"storylineText":): ,"value":
 
-# prevent the 'echo' logo to show, if article has no image
+# prevent the site logo to show, if article has no image
 insert_detected_image: no
 
 tidy: no

--- a/hochheimer-zeitung.de.txt
+++ b/hochheimer-zeitung.de.txt
@@ -1,4 +1,4 @@
-# test_url: http://...# chose your source feed from:
+# chose your source feed from:
 # https://www.hochheimer-zeitung.de/rss/
 
 # site has paywall, if you are using wallabag try to use
@@ -40,6 +40,9 @@ prune: no
 
 # wallabag only:
 wrap_in(blockquote): //div[contains(@class, 'quoteWrapper')]
+# prevents wallabag to show image galery as overlay above article text
+find_string: class="contentWrapper slider
+replace_string: class="contentWrapper foo
 
 # don't remove this line! Site belongs to de_VRM group
 

--- a/hochheimer-zeitung.de.txt
+++ b/hochheimer-zeitung.de.txt
@@ -1,0 +1,51 @@
+# test_url: http://...# chose your source feed from:
+# https://www.hochheimer-zeitung.de/rss/
+
+# site has paywall, if you are using wallabag try to use
+# wallabagger browser-plugin with activated option
+# 'Retrieve content from the browser' in it's settings
+
+http_header(User-Agent): Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
+http_header(referer): https://www.echo-online.de/
+
+body: //article
+author: //meta[@name='twitter:creator']/@content
+title: normalize-space(//meta[@property='og:title']/@content)
+date: //time/@datetime
+
+strip: //path
+strip: //script
+strip: //footer
+strip: //div[contains(@class, 'recommendations')]
+strip: //div[@data-testid='storyline-intro-authors']
+strip: //aside[contains(@data-testid, 'linkbox')]
+strip: //svg
+
+strip_id_or_class: recommendations__topStories
+strip_id_or_class: recommendations__cceWidget
+strip_id_or_class: storyElementWrapper__paywallContainer
+strip_id_or_class: storylineIntro__dateAndReadingTime
+strip_id_or_class: loadingBanner
+strip_id_or_class: adSlot
+strip_id_or_class: storylineHeader
+
+replace_string(,"value":): ,"invalid":
+replace_string(,"storylineText":): ,"value":
+
+# prevent the site logo to show, if article has no image
+insert_detected_image: no
+
+tidy: no
+prune: no
+
+# wallabag only:
+wrap_in(blockquote): //div[contains(@class, 'quoteWrapper')]
+
+# don't remove this line! Site belongs to de_VRM group
+
+# The first URL will at some point no longer show 
+# the full article. There is a time-based paywall 
+# Using the feed should present valid output
+
+#test_url: https://www.hochheimer-zeitung.de/lokales/hessen/trotz-demoverbots-anti-israelische-proteste-in-frankfurt-2943654
+test_url: https://www.hochheimer-zeitung.de/rss/lokales/hessen/

--- a/lampertheimer-zeitung.de.txt
+++ b/lampertheimer-zeitung.de.txt
@@ -1,0 +1,51 @@
+# test_url: http://...# chose your source feed from:
+# https://www.lampertheimer-zeitung.de/rss/lokales/hessen/
+
+# site has paywall, if you are using wallabag try to use
+# wallabagger browser-plugin with activated option
+# 'Retrieve content from the browser' in it's settings
+
+http_header(User-Agent): Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
+http_header(referer): https://www.echo-online.de/
+
+body: //article
+author: //meta[@name='twitter:creator']/@content
+title: normalize-space(//meta[@property='og:title']/@content)
+date: //time/@datetime
+
+strip: //path
+strip: //script
+strip: //footer
+strip: //div[contains(@class, 'recommendations')]
+strip: //div[@data-testid='storyline-intro-authors']
+strip: //aside[contains(@data-testid, 'linkbox')]
+strip: //svg
+
+strip_id_or_class: recommendations__topStories
+strip_id_or_class: recommendations__cceWidget
+strip_id_or_class: storyElementWrapper__paywallContainer
+strip_id_or_class: storylineIntro__dateAndReadingTime
+strip_id_or_class: loadingBanner
+strip_id_or_class: adSlot
+strip_id_or_class: storylineHeader
+
+replace_string(,"value":): ,"invalid":
+replace_string(,"storylineText":): ,"value":
+
+# prevent the site logo to show, if article has no image
+insert_detected_image: no
+
+tidy: no
+prune: no
+
+# wallabag only:
+wrap_in(blockquote): //div[contains(@class, 'quoteWrapper')]
+
+# don't remove this line! Site belongs to de_VRM group
+
+# The first URL will at some point no longer show 
+# the full article. There is a time-based paywall 
+# Using the feed should present valid output
+
+#test_url: https://www.lampertheimer-zeitung.de/lokales/hessen/trotz-demoverbots-anti-israelische-proteste-in-frankfurt-2943654
+test_url: https://www.lampertheimer-zeitung.de/rss/lokales/hessen/

--- a/lampertheimer-zeitung.de.txt
+++ b/lampertheimer-zeitung.de.txt
@@ -1,4 +1,4 @@
-# test_url: http://...# chose your source feed from:
+# chose your source feed from:
 # https://www.lampertheimer-zeitung.de/rss/lokales/hessen/
 
 # site has paywall, if you are using wallabag try to use
@@ -40,6 +40,9 @@ prune: no
 
 # wallabag only:
 wrap_in(blockquote): //div[contains(@class, 'quoteWrapper')]
+# prevents wallabag to show image galery as overlay above article text
+find_string: class="contentWrapper slider
+replace_string: class="contentWrapper foo
 
 # don't remove this line! Site belongs to de_VRM group
 

--- a/lauterbacher-anzeiger.de.txt
+++ b/lauterbacher-anzeiger.de.txt
@@ -1,0 +1,54 @@
+# chose your source feed from:
+# https://www.lauterbacher-anzeiger.de/rss/
+
+# site has paywall, if you are using wallabag try to use
+# wallabagger browser-plugin with activated option
+# 'Retrieve content from the browser' in it's settings
+
+http_header(User-Agent): Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
+http_header(referer): https://www.echo-online.de/
+
+body: //article
+author: //meta[@name='twitter:creator']/@content
+title: normalize-space(//meta[@property='og:title']/@content)
+date: //time/@datetime
+
+strip: //path
+strip: //script
+strip: //footer
+strip: //div[contains(@class, 'recommendations')]
+strip: //div[@data-testid='storyline-intro-authors']
+strip: //aside[contains(@data-testid, 'linkbox')]
+strip: //svg
+
+strip_id_or_class: recommendations__topStories
+strip_id_or_class: recommendations__cceWidget
+strip_id_or_class: storyElementWrapper__paywallContainer
+strip_id_or_class: storylineIntro__dateAndReadingTime
+strip_id_or_class: loadingBanner
+strip_id_or_class: adSlot
+strip_id_or_class: storylineHeader
+
+replace_string(,"value":): ,"invalid":
+replace_string(,"storylineText":): ,"value":
+
+# prevent the site logo to show, if article has no image
+insert_detected_image: no
+
+tidy: no
+prune: no
+
+# wallabag only:
+wrap_in(blockquote): //div[contains(@class, 'quoteWrapper')]
+# prevents wallabag to show image galery as overlay above article text
+find_string: class="contentWrapper slider
+replace_string: class="contentWrapper foo
+
+# don't remove this line! Site belongs to de_VRM group
+
+# The first URL will at some point no longer show 
+# the full article. There is a time-based paywall 
+# Using the feed should present valid output
+
+#test_url: https://www.lauterbacher-anzeiger.de/lokales/hessen/trotz-demoverbots-anti-israelische-proteste-in-frankfurt-2943654
+test_url: https://www.lauterbacher-anzeiger.de/rss/lokales/hessen/

--- a/lauterbacher-anzeiger.de.txt
+++ b/lauterbacher-anzeiger.de.txt
@@ -50,5 +50,5 @@ replace_string: class="contentWrapper foo
 # the full article. There is a time-based paywall 
 # Using the feed should present valid output
 
-#test_url: https://www.lauterbacher-anzeiger.de/lokales/hessen/trotz-demoverbots-anti-israelische-proteste-in-frankfurt-2943654
+#test_url: https://www.lauterbacher-anzeiger.de/lokales/rhein-main/oma-ute-goldener-zwiebelkuchen-zum-goldenen-herbst-2930710
 test_url: https://www.lauterbacher-anzeiger.de/rss/lokales/hessen/

--- a/main-spitze.de.txt
+++ b/main-spitze.de.txt
@@ -1,0 +1,51 @@
+# test_url: http://...# chose your source feed from:
+# https://www.main-spitze.de/rss/
+
+# site has paywall, if you are using wallabag try to use
+# wallabagger browser-plugin with activated option
+# 'Retrieve content from the browser' in it's settings
+
+http_header(User-Agent): Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
+http_header(referer): https://www.echo-online.de/
+
+body: //article
+author: //meta[@name='twitter:creator']/@content
+title: normalize-space(//meta[@property='og:title']/@content)
+date: //time/@datetime
+
+strip: //path
+strip: //script
+strip: //footer
+strip: //div[contains(@class, 'recommendations')]
+strip: //div[@data-testid='storyline-intro-authors']
+strip: //aside[contains(@data-testid, 'linkbox')]
+strip: //svg
+
+strip_id_or_class: recommendations__topStories
+strip_id_or_class: recommendations__cceWidget
+strip_id_or_class: storyElementWrapper__paywallContainer
+strip_id_or_class: storylineIntro__dateAndReadingTime
+strip_id_or_class: loadingBanner
+strip_id_or_class: adSlot
+strip_id_or_class: storylineHeader
+
+replace_string(,"value":): ,"invalid":
+replace_string(,"storylineText":): ,"value":
+
+# prevent the site logo to show, if article has no image
+insert_detected_image: no
+
+tidy: no
+prune: no
+
+# wallabag only:
+wrap_in(blockquote): //div[contains(@class, 'quoteWrapper')]
+
+# don't remove this line! Site belongs to de_VRM group
+
+# The first URL will at some point no longer show 
+# the full article. There is a time-based paywall 
+# Using the feed should present valid output
+
+#test_url: https://www.main-spitze.de/lokales/kreis-main-taunus/hochheim-kreis-main-taunus/a671-mainbruecke-nach-vollsperrung-bei-hochheim-wieder-offen-2938263
+test_url: https://www.main-spitze.de/rss/lokales/hessen/

--- a/main-spitze.de.txt
+++ b/main-spitze.de.txt
@@ -1,4 +1,4 @@
-# test_url: http://...# chose your source feed from:
+# chose your source feed from:
 # https://www.main-spitze.de/rss/
 
 # site has paywall, if you are using wallabag try to use
@@ -40,6 +40,9 @@ prune: no
 
 # wallabag only:
 wrap_in(blockquote): //div[contains(@class, 'quoteWrapper')]
+# prevents wallabag to show image galery as overlay above article text
+find_string: class="contentWrapper slider
+replace_string: class="contentWrapper foo
 
 # don't remove this line! Site belongs to de_VRM group
 

--- a/mittelhessen.de.txt
+++ b/mittelhessen.de.txt
@@ -1,0 +1,54 @@
+# test_url: http://...# chose your source feed from:
+# https://www.mittelhessen.de/rss/
+
+# site has paywall, if you are using wallabag try to use
+# wallabagger browser-plugin with activated option
+# 'Retrieve content from the browser' in it's settings
+
+http_header(User-Agent): Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
+http_header(referer): https://www.echo-online.de/
+
+body: //article
+author: //meta[@name='twitter:creator']/@content
+title: normalize-space(//meta[@property='og:title']/@content)
+date: //time/@datetime
+
+strip: //path
+strip: //script
+strip: //footer
+strip: //div[contains(@class, 'recommendations')]
+strip: //div[@data-testid='storyline-intro-authors']
+strip: //aside[contains(@data-testid, 'linkbox')]
+strip: //svg
+
+strip_id_or_class: recommendations__topStories
+strip_id_or_class: recommendations__cceWidget
+strip_id_or_class: storyElementWrapper__paywallContainer
+strip_id_or_class: storylineIntro__dateAndReadingTime
+strip_id_or_class: loadingBanner
+strip_id_or_class: adSlot
+strip_id_or_class: storylineHeader
+
+replace_string(,"value":): ,"invalid":
+replace_string(,"storylineText":): ,"value":
+
+# prevent the site logo to show, if article has no image
+insert_detected_image: no
+
+tidy: no
+prune: no
+
+# wallabag only:
+wrap_in(blockquote): //div[contains(@class, 'quoteWrapper')]
+# prevents wallabag to show image galery as overlay above article text
+find_string: class="contentWrapper slider
+replace_string: class="contentWrapper foo
+
+# don't remove this line! Site belongs to de_VRM group
+
+# The first URL will at some point no longer show 
+# the full article. There is a time-based paywall 
+# Using the feed should present valid output
+
+#test_url: https://www.allgemeine-zeitung.de/lokales/rheinhessen/zum-start-der-herbstferien-vollsperrung-der-l426-ab-montag-2937196
+test_url: https://www.mittelhessen.de/rss/lokales/hessen/

--- a/mittelhessen.de.txt
+++ b/mittelhessen.de.txt
@@ -50,5 +50,5 @@ replace_string: class="contentWrapper foo
 # the full article. There is a time-based paywall 
 # Using the feed should present valid output
 
-#test_url: https://www.allgemeine-zeitung.de/lokales/rheinhessen/zum-start-der-herbstferien-vollsperrung-der-l426-ab-montag-2937196
+#test_url: https://www.mittelhessen.de/lokales/wetteraukreis/butzbach-wetteraukreis/autozug-brand-in-butzbach-sperrung-aufgehoben-2942445
 test_url: https://www.mittelhessen.de/rss/lokales/hessen/

--- a/mittelhessen.de.txt
+++ b/mittelhessen.de.txt
@@ -1,4 +1,4 @@
-# test_url: http://...# chose your source feed from:
+# chose your source feed from:
 # https://www.mittelhessen.de/rss/
 
 # site has paywall, if you are using wallabag try to use

--- a/oberhessische-zeitung.de.txt
+++ b/oberhessische-zeitung.de.txt
@@ -1,0 +1,54 @@
+# chose your source feed from:
+# https://www.oberhessische-zeitung.de/rss/
+
+# site has paywall, if you are using wallabag try to use
+# wallabagger browser-plugin with activated option
+# 'Retrieve content from the browser' in it's settings
+
+http_header(User-Agent): Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
+http_header(referer): https://www.echo-online.de/
+
+body: //article
+author: //meta[@name='twitter:creator']/@content
+title: normalize-space(//meta[@property='og:title']/@content)
+date: //time/@datetime
+
+strip: //path
+strip: //script
+strip: //footer
+strip: //div[contains(@class, 'recommendations')]
+strip: //div[@data-testid='storyline-intro-authors']
+strip: //aside[contains(@data-testid, 'linkbox')]
+strip: //svg
+
+strip_id_or_class: recommendations__topStories
+strip_id_or_class: recommendations__cceWidget
+strip_id_or_class: storyElementWrapper__paywallContainer
+strip_id_or_class: storylineIntro__dateAndReadingTime
+strip_id_or_class: loadingBanner
+strip_id_or_class: adSlot
+strip_id_or_class: storylineHeader
+
+replace_string(,"value":): ,"invalid":
+replace_string(,"storylineText":): ,"value":
+
+# prevent the site logo to show, if article has no image
+insert_detected_image: no
+
+tidy: no
+prune: no
+
+# wallabag only:
+wrap_in(blockquote): //div[contains(@class, 'quoteWrapper')]
+# prevents wallabag to show image galery as overlay above article text
+find_string: class="contentWrapper slider
+replace_string: class="contentWrapper foo
+
+# don't remove this line! Site belongs to de_VRM group
+
+# The first URL will at some point no longer show 
+# the full article. There is a time-based paywall 
+# Using the feed should present valid output
+
+#test_url: https://www.oberhessische-zeitung.de/lokales/vogelsbergkreis/alsfeld-vogelsbergkreis/alsfelder-rambachhaus-reduziert-arbeitszeit-2940914
+test_url: https://www.oberhessische-zeitung.de/rss/lokales/hessen/

--- a/wiesbadener-kurier.de.txt
+++ b/wiesbadener-kurier.de.txt
@@ -1,4 +1,4 @@
-# test_url: http://...# chose your source feed from:
+# chose your source feed from:
 # https://www.wiesbadener-kurier.de/rss/
 
 # site has paywall, if you are using wallabag try to use
@@ -40,6 +40,9 @@ prune: no
 
 # wallabag only:
 wrap_in(blockquote): //div[contains(@class, 'quoteWrapper')]
+# prevents wallabag to show image galery as overlay above article text
+find_string: class="contentWrapper slider
+replace_string: class="contentWrapper foo
 
 # don't remove this line! Site belongs to de_VRM group
 

--- a/wiesbadener-kurier.de.txt
+++ b/wiesbadener-kurier.de.txt
@@ -41,6 +41,8 @@ prune: no
 # wallabag only:
 wrap_in(blockquote): //div[contains(@class, 'quoteWrapper')]
 
+# don't remove this line! Site belongs to de_VRM group
+
 # The first URL will at some point no longer show 
 # the full article. There is a time-based paywall 
 # Using the feed should present valid output

--- a/wiesbadener-kurier.de.txt
+++ b/wiesbadener-kurier.de.txt
@@ -1,0 +1,49 @@
+# test_url: http://...# chose your source feed from:
+# https://www.wiesbadener-kurier.de/rss/
+
+# site has paywall, if you are using wallabag try to use
+# wallabagger browser-plugin with activated option
+# 'Retrieve content from the browser' in it's settings
+
+http_header(User-Agent): Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
+http_header(referer): https://www.echo-online.de/
+
+body: //article
+author: //meta[@name='twitter:creator']/@content
+title: normalize-space(//meta[@property='og:title']/@content)
+date: //time/@datetime
+
+strip: //path
+strip: //script
+strip: //footer
+strip: //div[contains(@class, 'recommendations')]
+strip: //div[@data-testid='storyline-intro-authors']
+strip: //aside[contains(@data-testid, 'linkbox')]
+strip: //svg
+
+strip_id_or_class: recommendations__topStories
+strip_id_or_class: recommendations__cceWidget
+strip_id_or_class: storyElementWrapper__paywallContainer
+strip_id_or_class: storylineIntro__dateAndReadingTime
+strip_id_or_class: loadingBanner
+strip_id_or_class: adSlot
+strip_id_or_class: storylineHeader
+
+replace_string(,"value":): ,"invalid":
+replace_string(,"storylineText":): ,"value":
+
+# prevent the site logo to show, if article has no image
+insert_detected_image: no
+
+tidy: no
+prune: no
+
+# wallabag only:
+wrap_in(blockquote): //div[contains(@class, 'quoteWrapper')]
+
+# The first URL will at some point no longer show 
+# the full article. There is a time-based paywall 
+# Using the feed should present valid output
+
+#test_url: https://www.wiesbadener-kurier.de/lokales/wiesbaden/stadt-wiesbaden/keine-aktuelle-wiesbadener-buslinie-soll-fortbestehen-2940074
+test_url: https://www.wiesbadener-kurier.de/rss/lokales/hessen/

--- a/wormser-zeitung.de.txt
+++ b/wormser-zeitung.de.txt
@@ -1,0 +1,54 @@
+# chose your source feed from:
+# https://www.wormser-zeitung.de/rss/
+
+# site has paywall, if you are using wallabag try to use
+# wallabagger browser-plugin with activated option
+# 'Retrieve content from the browser' in it's settings
+
+http_header(User-Agent): Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
+http_header(referer): https://www.echo-online.de/
+
+body: //article
+author: //meta[@name='twitter:creator']/@content
+title: normalize-space(//meta[@property='og:title']/@content)
+date: //time/@datetime
+
+strip: //path
+strip: //script
+strip: //footer
+strip: //div[contains(@class, 'recommendations')]
+strip: //div[@data-testid='storyline-intro-authors']
+strip: //aside[contains(@data-testid, 'linkbox')]
+strip: //svg
+
+strip_id_or_class: recommendations__topStories
+strip_id_or_class: recommendations__cceWidget
+strip_id_or_class: storyElementWrapper__paywallContainer
+strip_id_or_class: storylineIntro__dateAndReadingTime
+strip_id_or_class: loadingBanner
+strip_id_or_class: adSlot
+strip_id_or_class: storylineHeader
+
+replace_string(,"value":): ,"invalid":
+replace_string(,"storylineText":): ,"value":
+
+# prevent the site logo to show, if article has no image
+insert_detected_image: no
+
+tidy: no
+prune: no
+
+# wallabag only:
+wrap_in(blockquote): //div[contains(@class, 'quoteWrapper')]
+# prevents wallabag to show image galery as overlay above article text
+find_string: class="contentWrapper slider
+replace_string: class="contentWrapper foo
+
+# don't remove this line! Site belongs to de_VRM group
+
+# The first URL will at some point no longer show 
+# the full article. There is a time-based paywall 
+# Using the feed should present valid output
+
+#test_url: https://www.wormser-zeitung.de/lokales/hessen/trotz-demoverbots-anti-israelische-proteste-in-frankfurt-2943654
+test_url: https://www.wormser-zeitung.de/rss/lokales/hessen/


### PR DESCRIPTION
fixed:
- echo-online.de

added:

- allgemeine-zeitung.de
- wiesbadener-kurier.de
- buerstaedter-zeitung.de
- hochheimer-zeitung.de
- lampertheimer-zeitung.de
- lauterbacher-anzeiger.de
- main-spitze.de
- mittelhessen.de
- oberhessische-zeitung.de
- wormser-zeitung.de