### PR TITLE
Update bostonglobe.com.txt

### DIFF
--- a/bostonglobe.com.txt
+++ b/bostonglobe.com.txt
@@ -1,10 +1,7 @@
-# NOTE:  If testing this configuration yields bad results, including junk text like "Try BostonGlobe.com today" and "THIS STORY APPEARED IN", please replace the Test URL with a current-day headline link from bostonglobe.com.
-
-title: //article//h1[contains(@class, 'title')]
-author: //div[contains(@class, "byline")]//span[contains(@class, 'author')]
+title: //main//h1[contains(@class, 'headline')]
+author: //div[contains(@class, "authors")]//*[contains(@class, "author")]
 date: //meta[@name="datePublished"]/@content
-#date: //div[@class="byline"]/p[last()]
-body: //article//h2[contains(@class, 'subheader')] | (//article//div[contains(@class, 'image')])[1] | //article[@id="article-body"]
+body: //main//h2[contains(@class, 'subheader')] | (//main//div[contains(@class, 'image')])[1] | //article[@id="article-body"]
 
 strip_id_or_class: bgmp-comments
 strip_id_or_class: aside
@@ -18,12 +15,21 @@ strip_id_or_class: newsletter
 strip_id_or_class: arc_ad
 strip_id_or_class: teads-inread
 strip_id_or_class: continue_button
+strip_id_or_class: affiliation
 
-# remove tiny image (full size not present in element)
-strip: //img[contains(@src, '/20x0/')]
+# remove tiny image (full size not present in element) [update Nov 2023: activating full size, see below] 
+#strip: //img/[contains(@src, '/20x0/')]/@src
 
 # This removes image captions.
-strip_id_or_class: figure
+#strip_id_or_class: figure
+
+find_string: " data-src="https://bostonglobe-prod.cdn.arcpublishing.com
+replace_string: " x src="https://bostonglobe-prod.cdn.arcpublishing.com
+
+find_string: " src="https://bostonglobe-prod.cdn.arcpublishing.com/resizer/
+replace_string: tinysrc="https://bostonglobe-prod.cdn.arcpublishing.com/resizer/
+
+prune: no
 
 test_url: https://www.bostonglobe.com/2020/04/07/metro/coronavirus-cases-surge-citys-safety-net-hospital-four-out-10-cases-are-now-related-pandemic/
 test_url: https://www.bostonglobe.com/2021/03/01/metro/charlie-youre-making-big-mistake-experts-criticize-states-monday-reopening/


### PR DESCRIPTION
- fixing meta fields from `//article...` to `/main...`
- fixing image loading (originally only a 20x15px micro-pix was shown)
- fixes https://github.com/wallabag/wallabag/issues/7094