### PR TITLE
Update news.ycombinator.com.txt to fix missing comments

### DIFF
--- a/news.ycombinator.com.txt
+++ b/news.ycombinator.com.txt
@@ -1,3 +1,5 @@
 strip_comments: no
 strip: //a[. = 'reply']
+replace_string("comment"): "commdiv"
+next_page_link: //a[@class='morelink']
 test_url: http://news.ycombinator.com/item?id=1516461


### PR DESCRIPTION
Changing class "comment" to "commdiv" to avoid these elements being deleted by readability (https://github.com/j0k3r/php-readability), see https://github.com/wallabag/wallabag/issues/4116. 
Additionally, `next_page_link` is added to locate the "More Comments..." link.