### PR TITLE
Update lemonde.fr.txt

### DIFF
--- a/lemonde.fr.txt
+++ b/lemonde.fr.txt
@@ -30,12 +30,16 @@ strip: //*[contains(@class, 'comments')]
 # Remove "Article réservé aux abonnés"
 strip: //p[@class='article__status']
 
+# Remove "Lecture restreinte Votre abonnement n’autorise pas la lecture de cet article"
+strip: //section[@id='js-capping-old-article']
+
 # Remove quotes highlighted in articles, doublons with content
 # We use parent::blockquote to avoid a remaining empty blockquote node
 strip: //p[@class='article__quote']/parent::blockquote
 
 # Remove share buttons
-strip://ul[contains(@class, 'meta__social')]
+strip: //ul[contains(@class, 'meta__social')]
+strip: //a[contains(@class, 'Header__offer')]
 
 # Remove the insane "conjugaison.lemonde.fr" links:
 find_string: <a target='_blank' onclick='return false;' class='lien_interne conjug'
@@ -68,3 +72,4 @@ test_url: http://www.lemonde.fr/economie/article/2011/07/05/moody-s-abaisse-la-n
 test_url: http://www.lemonde.fr/big-browser/article/2017/10/27/assassinat-de-kennedy-ce-qu-on-a-appris-dans-les-documents-declassifies_5207029_4832693.html
 test_url: https://www.lemonde.fr/pixels/article/2018/07/14/douze-jeux-video-pour-s-amuser-a-plusieurs_5331269_4408996.html
 test_url: https://www.lemonde.fr/sante/video/2016/04/07/diabete-pourquoi-une-telle-progression-de-l-epidemie_4898147_1651302.html
+test_url: https://www.lemonde.fr/pixels/article/2023/12/20/manettes-de-playstation-sony-condamne-a-13-5-millions-d-euros-d-amende-pour-des-pratiques-anticoncurrentielles_6206941_4408996.html


### PR DESCRIPTION
Remove: "Lecture restreinte
Votre abonnement n’autorise pas la lecture de cet article
Pour plus d’informations, merci de contacter notre service commercial."

And a link "Offrir Le Monde" at the beginning of some articles