### PR TITLE
Create docs.opnsense.org.txt

### DIFF
--- a/docs.opnsense.org.txt
+++ b/docs.opnsense.org.txt
@@ -1,0 +1,10 @@
+body: //div[@itemprop="articleBody"]
+
+strip: //div[@itemprop="articleBody"]//h1
+strip: //div[@id="table-of-contents"]
+strip: //a[contains(concat(' ',normalize-space(@class),' '),' headerlink ')]
+
+prune: no
+
+test_url: https://docs.opnsense.org/manual/firewall_generic.html
+test_url: https://docs.opnsense.org/manual/dhcp.html


### PR DESCRIPTION
The opnsense documentation website was mostly failing to load due to the pruning performed on each article.

While we're here, clean up the table of contents, the title of the document and the "¶" characters.