### PR TITLE
Add cohost.org ko-fi.com and pcgamer.com

### DIFF
--- a/cohost.org.txt
+++ b/cohost.org.txt
@@ -1,0 +1,6 @@
+body: //article
+body: //div[contains(concat(' ',normalize-space(@class),' '),' co-project-display-name ')]
+date: //time
+prune: no
+strip_id_or_class: co-comment-box
+strip_id_or_class: co-thread-footer

--- a/ko-fi.com.txt
+++ b/ko-fi.com.txt
@@ -1,0 +1,25 @@
+http_header(user-agent): Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
+
+strip_id_or_class: comments
+strip_id_or_class: upgrade_panel
+strip_id_or_class: kfds-lyt-between
+strip_id_or_class: kfds-lyt-between-end
+strip_id_or_class: recentPostsContainerDiv
+strip_id_or_class: postId
+strip_id_or_class: lbModal
+strip_id_or_class: checkoutModal
+strip_id_or_class: checkout-modal-skeleton
+
+title: //div[contains(concat(' ',normalize-space(@class),' '),' article-title ')]
+author: //name[contains(concat(' ',normalize-space(@class),' '),' post-name-row ')]
+date: //div[contains(concat(' ',normalize-space(@class),' '),' feeditem-time ')]
+# XXX: fails due to a #shadow-root inserted by the JS code...
+# When hacking the DOM in the browser to move the content of the shadow root as its sibling, 
+# Wallabager can then push a workable content to Wallabag
+body: //div[contains(concat(' ',normalize-space(@class),' '),' article-body ')]
+
+prune: yes
+tidy: yes
+
+test_url: https://ko-fi.com/post/Preparing-for-the-Spread-of-Avian-Influenza-H5N1-W7W4WFVW3
+test_contains: Ok, I know we've been here before, but let's go over the basics on preparedness for another pandemic.

--- a/pcgamer.com.txt
+++ b/pcgamer.com.txt
@@ -1,0 +1,14 @@
+body: //div[@id='content']
+
+strip_id_or_class: ad-unit
+strip_id_or_class: bordeaux-slot
+strip_id_or_class: slice-container-newsletterForm
+strip_id_or_class: author
+strip_id_or_class: slice-container-moreAbout
+strip_id_or_class: disqus_thread
+strip_id_or_class: jump-to-comments
+strip_id_or_class: related-articles
+strip_id_or_class: after-article-tags
+
+test_url: https://www.pcgamer.com/valves-unusual-corporate-structure-causes-its-problems-report-suggests/#article-comments
+test_contains: People Make Games' video report is over 45 minutes long


### PR DESCRIPTION
Ko-Fi fails due to a #shadow-root inserted by the JS code... It is however passible to hack the DOM in the browser to move the content of the shadow root as its sibling. Wallabager can then push a workable content to Wallabag