### PR TITLE
theguardian: update figure strip

### DIFF
--- a/theguardian.com.txt
+++ b/theguardian.com.txt
@@ -35,7 +35,9 @@ strip_id_or_class: youtube-media-atom__overlay
 
 strip: //figcaption
 strip: //svg
+strip: //gu-island/parent::figure
 strip: //gu-island
+strip: //figure//button
 
 title: //h1[@articleprop='headline']
 author: //a[@rel='author']


### PR DESCRIPTION
This fixes broken layout on wallabag by removing figure tags ending empty