### PR TITLE
Focus.de

### DIFF
--- a/focus.de.txt
+++ b/focus.de.txt
@@ -1,10 +1,9 @@
-title: //h1
-
-author: //div[@class='articleContent small']/div[@class='textBlock']//span[@class='created']
-
-date: //div[@class='articleHead']/span[@class='created']
-
+body: //article[@id='article']//div[contains(@class, 'mediaBlock')] | //article[@id='article']//div[contains(@class, 'leadIn')] | //article[@id='article']//div[contains(@class, 'textBlock')]
 body: //div[@id='article']
+
+title: //h1
+author: //div[@class='articleContent small']/div[@class='textBlock']//span[@class='created']
+date: //div[@class='articleHead']/span[@class='created']
 
 strip: //span[@class='markerText']
 strip: //div[@class='articleContent small']/div[@class='textBlock']//span[@class='created']
@@ -15,5 +14,11 @@ strip: //div[@id='commentForm']
 strip: //div[@id='commentSent']
 strip: //div[@id='comments']
 strip: //div[@class='similarityBlock']
+strip: //p[@class='noads']/parent::*
+
+replace_string(&nbsp;): 
+
+prune: no
+tidy: no
 
 test_url: http://www.focus.de/politik/ausland/ein-jahr-nach-bombenanschlag-u-bahn-attentaeter-von-minsk-hingerichtet_aid_724958.html

--- a/focus.de.txt
+++ b/focus.de.txt
@@ -14,11 +14,13 @@ strip: //div[@id='commentForm']
 strip: //div[@id='commentSent']
 strip: //div[@id='comments']
 strip: //div[@class='similarityBlock']
-strip: //p[@class='noads']/parent::*
 
+#remove related article ads
+strip: //p[@class='noads']/parent::*
 replace_string(&nbsp;): 
 
 prune: no
 tidy: no
 
 test_url: http://www.focus.de/politik/ausland/ein-jahr-nach-bombenanschlag-u-bahn-attentaeter-von-minsk-hingerichtet_aid_724958.html
+test_url: https://www.focus.de/auto/gebrauchtwagen/oldtimer/immer-mehr-elektronik-die-oldtimer-von-morgen-bekommen-ein-erhebliches-ersatzteil-problem_id_260032988.html


### PR DESCRIPTION
- fixed body selector. The old one doesn't exist at least in newer articles
- the new body selector now contains lead image
- remove (un)related article ads
- activate image links to video content (prune: no), see 2nd test_url