### PR TITLE
Update vienna.at.txt

### DIFF
--- a/vienna.at.txt
+++ b/vienna.at.txt
@@ -1,3 +1,13 @@
+# official feed (sometimes doen't work):
+# https://www.vienna.at/news/wien/rss
+#
+# alternativly use https://createfeed.fivefilters.org/  with
+# url=https://www.vienna.at/news/wien/
+# item=.vodl-news-river__item-inner
+# item_title=h2
+# item_desc=span
+# strip=strong
+
 body: //div[@class='vodl-region-article']/div[1]
 
 strip_id_or_class: vodl-region-article__category-label
@@ -13,6 +23,10 @@ strip: //div[@data-type='video']
 
 prune: no
 tidy: no
+
+# Some articles contain illegal characters with byte value 0x02
+# as conditional hyphenator. This causes an XML parsing error in FTR.
+replace_string():
 
 # activate lead image for wallabag
 strip: //picture/source


### PR DESCRIPTION
Some articles contain illegal characters with byte value 0x02 as conditional hyphenator. This causes an XML parsing error in FTR.