### PR TITLE
Update bonpote.com.txt

### DIFF
--- a/bonpote.com.txt
+++ b/bonpote.com.txt
@@ -1,3 +1,18 @@
+body: //div[contains(@class, 'elementor-widget-theme-post-content')] | //div[contains(@class, 'post-featured-image')]
+author: //meta[@name='author']/@content
+
 strip: //table[@id="trinity-audio-table"]
+strip: //svg
+
+strip_id_or_class: elementor-hidden-desktop
+
+# subheadings missing in wallabag
+replace_string(class="wp-block-heading"): class="foo-wpbh"
+replace_string(<h2): <h3
+replace_string(</h2>): </h3>
+
+prune: no
+tidy: no
 
 test_url: https://bonpote.com/le-bonheur-a-quel-prix-pour-lenvironnement/
+test_url: https://bonpote.com/decroissance-et-prejuges/


### PR DESCRIPTION
- follow up to https://github.com/fivefilters/ftr-site-config/pull/1410
- wallabag didn't show subheadings due to class="wp-block-heading"
- some articles where incomplete, so now providing a body selector
- include lead image to the article