### PR TITLE
Update .vanityfair.com.txt

### DIFF
--- a/.vanityfair.com.txt
+++ b/.vanityfair.com.txt
@@ -1,4 +1,6 @@
-body: //div[contains(@class, '_article_body')] | //div[contains(@class, 'bndwgt__info')]
+# can't use //h3 for lead text, because wallabag is removing <span> tags within that <h3> and
+# concatenate their content (issue date, authors) with the leadtext
+body: //div[contains(@class, '_article_body')] | //div[contains(@class, 'bndwgt__info')]//p
 title: substring-before(//meta[@property="og:title"]/@content , ' | Vanity Fair')
 
 strip_id_or_class: bnd_artpg_hero_wrap


### PR DESCRIPTION
- wallabag concatenated lead text with issue date and authors, due to their auto-removing of span tags. I hate that behavior! So I need to grab the //p instead of //h3
- because of this change, the lead text is normal text now, instead of h3