### PR TITLE
Nyt

### DIFF
--- a/mobile.nytimes.com.txt
+++ b/mobile.nytimes.com.txt
@@ -7,6 +7,10 @@ body://div[@id="article"]
 body://*[@itemprop="articleBody"]
 body: //div[contains(concat(' ',normalize-space(@class),' '),' g-body-article-container ')]
 body: //article[@id='story']
+body: //article[1]
+
+strip: //*[@data-scp="removed"]
+
 strip_id_or_class:articleTools
 strip_id_or_class:readerscomment
 #strip://div[contains(@class, "articleInline runaroundLeft")]

--- a/nytimes.com.txt
+++ b/nytimes.com.txt
@@ -11,6 +11,9 @@ body://div[@id="article"]
 body://*[@itemprop="articleBody"]
 body: //div[contains(concat(' ',normalize-space(@class),' '),' g-body-article-container ')]
 body: //article[@id='story']
+body: //article[1]
+
+strip: //*[@data-scp="removed"]
 strip_id_or_class:articleTools
 strip_id_or_class:readerscomment
 #strip://div[contains(@class, "articleInline runaroundLeft")]


### PR DESCRIPTION
add support for /wirecutter/

example:
https://www.nytimes.com/wirecutter/reviews/wirecutter-show-podcast-20240821-better-laundry-secret/