### PR TITLE
Matt2

### DIFF
--- a/matthewball.co.txt
+++ b/matthewball.co.txt
@@ -11,12 +11,11 @@ strip_id_or_class: newsletter-form-wrapper
 strip_id_or_class: blog-item-author-profile-wrapper
 strip_id_or_class: blog-item-comments
 
-
 # images from galery
 find_string: data-src="https://
 replace_string: src="https://
 find_string: <noscript>
-replace_string: <div class="wp-block-heading" style="display:none;">
+replace_string: <div style="display:none;">
 find_string: </noscript>
 replace_string: </div>
 

--- a/matthewball.co.txt
+++ b/matthewball.co.txt
@@ -11,10 +11,17 @@ strip_id_or_class: newsletter-form-wrapper
 strip_id_or_class: blog-item-author-profile-wrapper
 strip_id_or_class: blog-item-comments
 
+
 # images from galery
 find_string: data-src="https://
 replace_string: src="https://
+find_string: <noscript>
+replace_string: <div class="wp-block-heading" style="display:none;">
+find_string: </noscript>
+replace_string: </div>
 
 prune: no
+tidy: no
   
 test_url: https://www.matthewball.co/all/applevision2024
+test_url: https://www.matthewball.co/all/zztmetaverse


### PR DESCRIPTION
* re-inserted 2 string replacements to prevent double images from galleries. [PushToKindle]
* added `tidy: no` to prevent [wallabag] from showing double images, which is introduced by the above string replacements

ughh