### PR TITLE
Update taz.de.txt

### DIFF
--- a/taz.de.txt
+++ b/taz.de.txt
@@ -1,5 +1,19 @@
-date: //li[@class='date']
-author: (//h4[@itemprop='name'])[1]
+body: //article[1]
 
+strip_id_or_class: tzi-bottom-container
+strip_id_or_class: author-container
+strip_id_or_class: meta-data-container
+strip_id_or_class: is-hidden
+
+strip: //h1[1]
+
+# replace micro-img with noscipt-img
+strip: //img[contains(@src, '/14/')]
+replace_string(noscript>): div>
+
+prune: no
+tidy: no
+
+test_url: https://taz.de/Italienische-Comicneuheiten/!6041889/
 test_url: https://www.taz.de/!5504959/
 test_url: https://taz.de/!5708122


### PR DESCRIPTION
- taz.de had a complete redesign at Oct 15, 2024 so selectors didn't fit any longer. fixed.
- fixes #1444