### PR TITLE
Update mailchi.mp.txt

### DIFF
--- a/mailchi.mp.txt
+++ b/mailchi.mp.txt
@@ -9,12 +9,15 @@ replace_string(<td): <div
 replace_string(</td): </div
 
 body: //div[@id="bodyTable"]
+body: //body[1]
 
+strip_id_or_class: awesomewrap
 strip_id_or_class: templatePreheader
 strip_id_or_class: mcnShareBlock
 strip_id_or_class: templateFooter
 strip_id_or_class: mcnFollowBlock
 
 prune: no
+
 
 # Test URL needs to be something that doesn't reveal a subscriber's email address


### PR DESCRIPTION
maybe new or different layout prevents some newsletters to fetch. So as fallback the whole `<body>` will be used