### PR TITLE
Mediapart

### DIFF
--- a/mediapart.fr.txt
+++ b/mediapart.fr.txt
@@ -14,6 +14,8 @@ strip_id_or_class: engagement-bar-wrapper
 strip_id_or_class: read-also
 strip_id_or_class: newsletter-form
 
+strip: //button
+
 # prevent wallabag from tinyfying paragraphs
 find_string: class="container
 replace_string: class="foo_cntr

--- a/mediapart.fr.txt
+++ b/mediapart.fr.txt
@@ -1,4 +1,5 @@
 title://h1[@class="title"]
+body: //main[1]
 body://main[@class="global-wrapper"]
 
 date: //div[contains(concat(' ',normalize-space(@class),' '),' author ')]//time/@datetime
@@ -8,15 +9,20 @@ single_page_link: //link[@rel="canonical"]
 
 strip: //aside
 
+strip_id_or_class: news__body__right
+strip_id_or_class: paywall-login
+strip_id_or_class: paywall-message
+
 requires_login: yes
 
-login_uri: https://www.mediapart.fr/login_check
+login_uri: //meta[@property="og:url"]/@content
 login_username_field: email
 login_password_field: password
 
-login_extra_fields: formulaire_action="/login_check"
-login_extra_fields: op=Se+connecter
+login_extra_fields: action="/login_check"
+login_extra_fields: novalidate="novalidate"
+login_extra_fields: accept-charset="UTF-8"
 
-not_logged_in_xpath: //body[contains(@class,"not-logged-in")]
+not_logged_in_xpath: //div[contains(@class,"paywall-login")]
 
 test_url: https://www.mediapart.fr/journal/france/170116/le-site-slatefr-est-passe-entre-les-mains-du-cac-40

--- a/mediapart.fr.txt
+++ b/mediapart.fr.txt
@@ -1,28 +1,40 @@
 title://h1[@class="title"]
-body: //main[1]
-body://main[@class="global-wrapper"]
-
+body://main[1]
 date: //div[contains(concat(' ',normalize-space(@class),' '),' author ')]//time/@datetime
 author: //div[contains(concat(' ',normalize-space(@class),' '),' author ')]//a[@class='journalist']
 
 single_page_link: //link[@rel="canonical"]
 
-strip: //aside
-
 strip_id_or_class: news__body__right
-strip_id_or_class: paywall-login
-strip_id_or_class: paywall-message
+strip_id_or_class: news__heading__top__kicker
+strip_id_or_class: page-title
+strip_id_or_class: news__heading__center
+strip_id_or_class: splitter
+strip_id_or_class: engagement-bar-wrapper
+strip_id_or_class: read-also
+strip_id_or_class: newsletter-form
 
+# prevent wallabag from tinyfying paragraphs
+find_string: class="container
+replace_string: class="foo_cntr
+
+prune: no
+tidy: no
+
+### wallabag only
+### do NOT provide your credentials here, they must be stored in wallabag's UI
+
+wrap_in(blockquote): //aside[contains(@class, 'highlight')]
 requires_login: yes
 
-login_uri: //meta[@property="og:url"]/@content
+login_uri: https://www.mediapart.fr/login_check
 login_username_field: email
 login_password_field: password
 
-login_extra_fields: action="/login_check"
-login_extra_fields: novalidate="novalidate"
-login_extra_fields: accept-charset="UTF-8"
+login_extra_fields: formulaire_action="/login_check"
+login_extra_fields: op=Se+connecter
 
-not_logged_in_xpath: //div[contains(@class,"paywall-login")]
+not_logged_in_xpath: //body[contains(@class,"not-logged-in")]
+
 
 test_url: https://www.mediapart.fr/journal/france/170116/le-site-slatefr-est-passe-entre-les-mains-du-cac-40


### PR DESCRIPTION
- fixes https://github.com/wallabag/wallabag/issues/7634

known issue [wallabag]:
- paragraphs starting with an initial (larger first letter of a word) the first word is doubled up. That can't be prevented, because wallabag strips all span nodes and just keeps the text between.