### PR TITLE
Update heise.de.txt

### DIFF
--- a/heise.de.txt
+++ b/heise.de.txt
@@ -86,7 +86,6 @@ replace_string( | heise Autos</title>): </title>
 replace_string(<div class="heisebox">): <blockquote>
 
 single_page_link: //a[contains(@href, '?view=print')]
-single_page_link: //a[contains(@title, 'Druck')]
 single_page_link: //a[contains(@href, '?seite=all')]/@href
 
 next_page_link: //a[@class='next' and not(contains(text(), 'Artikel'))]


### PR DESCRIPTION
removed -> `single_page_link: //a[contains(@title, 'Druck')]`
because some different articles always showed the same content, because one of the hidden overlay-links contains 'Drucker' in the title.

Druck = (to) print
Drucker = (ink, laser, color, 3D, ...) printer

example: this article
https://www.heise.de/bestenlisten/testsieger/top-10-das-beste-heizkoerperthermostat-im-test/1e43f3r
and most other articles of the kind 'top-10 of \<product-category\>' shows content of
https://www.heise.de/bestenlisten/testsieger/top-10-der-beste-3d-drucker-mit-filament-im-test/jrel4jt