### PR TITLE
Fix lwn.net login

### DIFF
--- a/lwn.net.txt
+++ b/lwn.net.txt
@@ -35,8 +35,8 @@ strip: //table[@class='Form']
 requires_login: yes
 
 login_uri: https://lwn.net/Login/
-login_username_field: Username
-login_password_field: Password
+login_username_field: uname
+login_password_field: pword
 
 not_logged_in_xpath: /html/body/div[3]/div[1]/form[@class="loginform"]
 


### PR DESCRIPTION
Recently LWN subscription-only articles stopped loading in Wallabag. Seemingly the Username and Password fields changed to uname and pword.
After making this change, wallabag now fetches the articles correctly.