### PR TITLE
Update markmanson.net.txt

### DIFF
--- a/markmanson.net.txt
+++ b/markmanson.net.txt
@@ -1,3 +1,4 @@
+body: //article//div[contains(concat(' ',normalize-space(@class),' '),' article-content ')]
 body: //article//div[contains(concat(' ',normalize-space(@class),' '),' entry-content ')]
 author: //meta[@property="article:author"]/@content
 date: //meta[@property="article:published_time"]/@content
@@ -5,8 +6,8 @@ title: //h1[contains(concat(' ',normalize-space(@class),' '),' entry-title ')]
 
 strip_id_or_class: article-audio-player
 strip_id_or_class: in-article-opt-in
-strip_id_or_class: footer-opt-in
 strip_id_or_class: no-print
+
 
 # Let's use img in <noscript> instead
 strip_id_or_class: lazyloaded


### PR DESCRIPTION
- former body class, used as selector, has changed within last 3 weeks
- stripping class 'footer-opt-in' breaks FTR fetch. As the class field also contains the stripped 'no-print' class, the additional strip is not necessary.
- fixes https://github.com/wallabag/wallabag/issues/7935