### PR TITLE
muse.jhu.edu.txt added for the journal of democracy

### DIFF
--- a/muse.jhu.edu.txt
+++ b/muse.jhu.edu.txt
@@ -1,0 +1,25 @@
+test_url: https://muse.jhu.edu/article/947886
+
+# default handling breaks a number of things
+prune: no
+tidy: no
+
+title: //meta[@name="citation_title"]/@content
+author: //meta[@name="citation_author"]/@content
+body: //div[@id="article"]
+strip: //div[@class="card row"]
+
+# remove inserted "end of page" notes in text
+strip: //strong[contains(text(),"End Page ")]
+
+# format figures a bit better
+find_string: class="figure"
+replace_string: class="container figure"
+
+# enlarge images
+find_string: ?format=thumb
+replace_string:
+
+# removing hint and link to full size image
+strip: //div[@class='thumbnail']/text()
+strip: //div[@class='thumbnail']/a[2]


### PR DESCRIPTION
Hi,

I hope this PR is all right - it's the first one I open here and one of the first ones ever for me.

I'm adding a file for the domain muse.jhu.edu which is where the Journal of Democracy stores full-length articles. I've benefitted from HolgerAusB over at the Wallabag repo to prepare this file and it now works nicely with that journal.

Cheers
Pierric.