### PR TITLE
Remove "Optimize your browser settings" text

### DIFF
--- a/nzz.ch.txt
+++ b/nzz.ch.txt
@@ -9,6 +9,7 @@ strip: //header[@class='group']
 strip: //div[@id='social-media-floater']
 strip: //div[@class='advertisement']
 strip: //div[@class='infobox']
+strip: //div[@class='disabled-overlay--show--text']
 strip: //div[@id='articleComments']
 strip: //section[@componenttype='moreToSubject']
 


### PR DESCRIPTION
This removes the note to "enable javascript" (see below), which appears in every article since a few months.


Optimieren Sie Ihre Browsereinstellungen

NZZ.ch benötigt JavaScript für wichtige Funktionen. Ihr Browser oder Adblocker verhindert dies momentan.

Bitte passen Sie die Einstellungen an.
