### PR TITLE
Wired

### DIFF
--- a/wired.com.txt
+++ b/wired.com.txt
@@ -3,6 +3,7 @@
 body: //div[contains(concat(' ',normalize-space(@class),' '),' ArticlePageContentBackGround-cNiFNN ')]
 body: //div[@id='container']
 strip: //button
+strip: //div[contains(@class, 'RecircMostPopularWrapper')]
 
 # [wallabag]: activate sub-headings
 prune: no

--- a/wired.com.txt
+++ b/wired.com.txt
@@ -1,6 +1,11 @@
+# Images are not loaded, because they are not relative to www.wired.com as claimed in src field of <img>
+
 body: //div[contains(concat(' ',normalize-space(@class),' '),' ArticlePageContentBackGround-cNiFNN ')]
+body: //div[@id='container']
 strip: //button
-strip: //div[contains(@class, 'RecircMostPopularWrapper')]
+
+# [wallabag]: activate sub-headings
+prune: no
 
 test_url: https://www.wired.com/story/tiktok-platforms-cory-doctorow/
 test_contains: they are good to their users


### PR DESCRIPTION
- add 2nd body selector
- add `prune: no` to un-hide sub-headings in wallabag
- hint that images are not loaded

e.g.: https://www.wired.com/2014/09/coupland-bell-labs/