### PR TITLE
Update phys.org.txt

### DIFF
--- a/phys.org.txt
+++ b/phys.org.txt
@@ -1,1 +1,4 @@
-http_header(user-agent): Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) Gecko/20100101 Firefox/133.0
+http_header(User-Agent): Mastodon/4.3.2 (http.rb/5.2.0; +https://mastodon.social/) Bot
+
+test_url: https://phys.org/news/2025-03-dark-universe-telescope.html
+test_url: https://phys.org/rss-feed/breaking/space-news/


### PR DESCRIPTION
changed user-agent, because if server is rent and not hosted locally website might deny to send content. ref: https://forum.fivefilters.org/t/unable-to-retrieve-full-text-content-at-phys-org/