### PR TITLE
Create jvns.ca.txt

### DIFF
--- a/jvns.ca.txt
+++ b/jvns.ca.txt
@@ -1,0 +1,14 @@
+body: //div[@id='content']//article/main
+author: //meta[@name='author']/@content
+date: //time/@datetime
+
+# prevent wallabg from stripping sub-headings:
+strip_attr: //h3/@class
+
+# un-link the subheadings
+find_string: <a href="#
+replace_string: <span foo="#
+
+prune: no
+
+test_url: https://jvns.ca/blog/2023/11/10/how-cherry-pick-and-revert-work/#so-what-does-git-apply-do


### PR DESCRIPTION
- fixed: wallabag did not show h3 subheadings
- fixed: subheadings are linked to their own `#id` on the source article [wallabag]
- fixes https://github.com/wallabag/wallabag/issues/8144