### PR TITLE
Update publicdomainreview.org.txt

### DIFF
--- a/publicdomainreview.org.txt
+++ b/publicdomainreview.org.txt
@@ -1,9 +1,17 @@
-body: //div[contains(@class, 'essay-body') or contains(@class, 'essay-intro')]
+body: //div[contains(@class, 'essay-body')] | //div[contains(@class, 'essay-intro')] | //div[contains(@class, 'collection-embed')] | //div[contains(@class, 'collection-preamble')]
+
 title: //meta[@property="og:title"]/@content
 date: //div[@class="essay-intro"]/p[@class="date"]
 author: //div[@class="essay-header"]/p[@class="byline"]/a
+
+strip: //svg/parent::a
+strip: //*[contains(text(), 'Scroll through the whole page to download all images')]/text()
+
+strip_id_or_class: essay__right-bar
+
 
 prune: no
 
 test_url: https://publicdomainreview.org/essay/fungi-folklore-and-fairyland
 test_contains: By chance a physician named Everard Brande
+test_url: https://publicdomainreview.org/collection/utsuro-bune/


### PR DESCRIPTION
- removed 'or' in body selector and replaced with '|' for concatenating parts.
- added mores concatenated selectors for body to support articles from the `/collection/` area
- removed anchor link `<svg>` symbol
- fixes https://github.com/wallabag/wallabag/issues/8321