### PR TITLE
Update monde-diplomatique.fr.txt

### DIFF
--- a/monde-diplomatique.fr.txt
+++ b/monde-diplomatique.fr.txt
@@ -26,7 +26,7 @@ strip: //div[@class='cartouche']/p[contains(@class, 'surtitre')]
 replace_string(chapo"><p>): chapo"><h5>
 
 prune: no
-tidy: yes
+tidy: no
 
 # wallabag only
 # do not set you credentials here, you have to do this in wallabag's UI

--- a/monde-diplomatique.fr.txt
+++ b/monde-diplomatique.fr.txt
@@ -21,9 +21,12 @@ author: //meta[@property='article:author']/@content
 strip: //div[contains(@class, 'bandeautitre')]
 strip: //div[contains(@class, 'dates_auteurs')]
 strip: //div[@class='cartouche']/h1
+strip: //div[@class='cartouche']/p[contains(@class, 'surtitre')]
+
+replace_string(chapo"><p>): chapo"><h5>
 
 prune: no
-tidy: no
+tidy: yes
 
 # wallabag only
 # do not set you credentials here, you have to do this in wallabag's UI


### PR DESCRIPTION
- Remove `<div>` elements with class `surtitre`: These elements serve as surtitles and should appear above the main article title to preserve the correct content hierarchy. Since proper placement isn’t feasible at the moment, they are removed to avoid being incorrectly included as part of the article content.

- Replace introduction/summary paragraphs (tags ending in `chapo`) with `<h5>` elements: This helps visually and semantically distinguish them from the main body of the article.

- Enable `tidy `to correct the issues that appear when replacing opening tags with another like the `<h5>` just above

Original article
<img src="https://github.com/user-attachments/assets/45d0fc2a-64aa-45ce-8bf6-fdc2ee9effd5" width="200" />

Before modifications
<img src="https://github.com/user-attachments/assets/fba0adb6-5846-4c70-8456-dd40fce1bb4c" width="200" />

After modifications
<img src="https://github.com/user-attachments/assets/cf605c19-3e35-4b2b-902f-ca1670f42425" width="200" />