### PR TITLE
Fix for theguardian

### DIFF
--- a/theguardian.com.txt
+++ b/theguardian.com.txt
@@ -18,6 +18,7 @@ strip: //footer
 strip: //form
 strip: //div[starts-with(@id, "qanda-")]
 strip: //button
+strip: //div[contains(@class, 'ad-slot-container')]
 
 strip: //figure[contains(@data-spacefinder-type, "NewsletterSignup")]
 strip: //figure[@data-atom-type="qanda" or @data-atom-type="profile"]


### PR DESCRIPTION
Strip div ads, so that the entire article is present in the result.