### PR TITLE
Update monde-diplomatique.fr.txt

### DIFF
--- a/monde-diplomatique.fr.txt
+++ b/monde-diplomatique.fr.txt
@@ -23,7 +23,7 @@ strip: //div[contains(@class, 'dates_auteurs')]
 strip: //div[@class='cartouche']/h1
 strip: //div[@class='cartouche']/p[contains(@class, 'surtitre')]
 
-replace_string(chapo"><p>): chapo"><h5>
+replace_string(chapo"><p>): chapo"><h6>
 
 prune: no
 tidy: no


### PR DESCRIPTION
After testing with real cases, it appears that `h5` is too large for the article introduction. Using `h6` feels more natural and looks closer to the original content.