### PR TITLE
Update mediapart.fr.txt

### DIFF
--- a/mediapart.fr.txt
+++ b/mediapart.fr.txt
@@ -19,9 +19,13 @@ strip_id_or_class: paywall-message
 strip_id_or_class: paywall_no_variance
 
 strip_id_or_class:  screen-reader-only
-replace_string(<span class="screen-reader-only">): <span class="screen-reader-only"
 
-replace_string(<p class="news__heading__top__intro): <h6 class="news__heading__top__intro
+# self-hosters of wallabag may activate following line to prevent doubled word at regulart text start (problem with initial)
+# as this is causing problem with other products, standard is de-activated
+#replace_string(<span class="screen-reader-only">): <span class="screen-reader-only"
+
+# [wallabag] inject class 'hljs-strong' to emphasise the lead paragraph
+replace_string(<p class="news__heading__top__intro): <p class="hljs-strong news__heading__top__intro
 
 strip: //button
 

--- a/mediapart.fr.txt
+++ b/mediapart.fr.txt
@@ -18,6 +18,11 @@ strip_id_or_class: paywall-login
 strip_id_or_class: paywall-message
 strip_id_or_class: paywall_no_variance
 
+strip_id_or_class:  screen-reader-only
+replace_string(<span class="screen-reader-only">): <span class="screen-reader-only"
+
+replace_string(<p class="news__heading__top__intro): <h6 class="news__heading__top__intro
+
 strip: //button
 
 # prevent wallabag from tinyfying paragraphs


### PR DESCRIPTION
- `replace_string(<span class="screen-reader-only">): <span class="screen-reader-only"` is used to make the article introduction a little bolder to distinguish it from the rest of the article, like it is in the original web render of the article

- `strip_id_or_class: screen-reader-only` and `replace_string(<p class="news__heading__top__intro): <h6 class="news__heading__top__intro"` are used to remove content that is not expected to be displayed in the text render, especially the article date and the drop cap at the beginning of the article. The replace_string is a workaround to remove this drop cap because, for some reason, strip_id_or_class does not work for this specific element.