### PR TITLE
add publication date and author to arXiv

### DIFF
--- a/arxiv.org.txt
+++ b/arxiv.org.txt
@@ -2,5 +2,8 @@ title: //h1[contains(concat(' ',normalize-space(@class),' '),' title ')]
 
 body: //blockquote[contains(concat(' ',normalize-space(@class),' '),' abstract ')]
 
+date: //meta[@name='citation_date']/@content
+author: //meta[@name='citation_author']/@content
+
 test_url: https://arxiv.org/abs/2009.03017
 test_url: https://arxiv.org/abs/2012.03780


### PR DESCRIPTION
Context (if curious who is using your filters): I would like to use a tool called [readeck](https://codeberg.org/readeck/readeck) to collect my arXiv links. Currently, it does not contain publication dates. I was going to add it [here](https://codeberg.org/readeck/readeck/pulls/793) but was recommended to rather push this upstream to five filters.


Note that there is only one publication date, but there can be multiple authors.

Thanks!