### PR TITLE
chore: add configuration file for spacetoday.com.br

### DIFF
--- a/spacetoday.com.br.txt
+++ b/spacetoday.com.br.txt
@@ -1,0 +1,6 @@
+body: //div[@class='entry-content-single']
+
+strip: //iframe
+
+test_url: https://spacetoday.com.br/astronomos-detectam-o-buraco-negro-mais-antigo-no-amanhecer-cosmico/
+test_url: https://spacetoday.com.br/o-risco-real-de-colisao-de-objetos-proximos-com-a-terra/

--- a/spacetoday.com.br.txt
+++ b/spacetoday.com.br.txt
@@ -1,6 +1,9 @@
 body: //div[@class='entry-content-single']
+author: //h4[contains(@class, 'author-title')]
 
 strip: //iframe
+
+strip_id_or_class: vlog-share-single
 
 test_url: https://spacetoday.com.br/astronomos-detectam-o-buraco-negro-mais-antigo-no-amanhecer-cosmico/
 test_url: https://spacetoday.com.br/o-risco-real-de-colisao-de-objetos-proximos-com-a-terra/


### PR DESCRIPTION
This PR adds a configuration file for spacetoday.com.br to remove the iframe that displays a PDF at the end of some articles. The PDF serves only as a reference and should not be included.