### PR TITLE
taz.de: fix stripping noscript tags that have attributes

### DIFF
--- a/taz.de.txt
+++ b/taz.de.txt
@@ -9,7 +9,8 @@ strip: //h1[1]
 
 # replace micro-img with noscipt-img
 strip: //img[contains(@src, '/14/')]
-replace_string(noscript>): div>
+replace_string(<noscript): <div
+replace_string(</noscript>): </div>
 
 # remove blank in meta>og:image>content, which resulted in an empty preview image in wallabag
 replace_string(.jpeg "): .jpeg"
@@ -20,3 +21,4 @@ tidy: no
 test_url: https://taz.de/Italienische-Comicneuheiten/!6041889/
 test_url: https://www.taz.de/!5504959/
 test_url: https://taz.de/!5708122
+test_url: https://taz.de/Ankommen-in-Deutschland-als-Gefluechtete/!6103413/


### PR DESCRIPTION
An article on the site `taz.de` has this markup:

    <noscript class="html-content" type="text/plain">
      <div class="flourish-embed flourish-cards" data-src="visualisation/24645741>
        <script src="https://public.flourish.studio/resources/embed.js"></script>
      </div>
    </noscript>

It's extremely uncommon for noscript tags to have HTML attributes, but it's technically legal HTML and this document has it, with the consequence being that applying the `replace_string` directive effectively ruins the document as everything after the offending noscript tag will be subsumed by the tag:

    <noscript class="html-content" type="text/plain">
      ...
    </div>

The fix is to match and replace the opening `<noscript` and the closing `</noscript>` tag separately, allowing for the opening tag to have HTML attributes.

Bug first discovered by [bannmann](https://codeberg.org/bannmann) at https://codeberg.org/readeck/readeck/issues/807

⚠️ Important note: there are [dozens of other site rules](https://github.com/search?q=repo:fivefilters/ftr-site-config%20/replace_string.+noscript/&type=code) in this repository that aim to replace `<noscript>` tags but do not account for the fact that the opening tag might have HTML attributes, and all of them are vulnerable to this same bug. I've chosen to only fix this site for now.