### PR TITLE
Update selectors and strip rules in golem.de.txt

### DIFF
--- a/golem.de.txt
+++ b/golem.de.txt
@@ -60,8 +60,8 @@ strip: //figure[contains(@id,'gvideo')]
 strip: //figure/figcaption[contains(text(), 'Bitte aktivieren Sie Javascript')]
 
 # Tidy up links
-strip_attr: a@title
-strip_attr: a@target
+strip_attr: //a/@title
+strip_attr: //a/@target
 strip: //span[@class='go-vh' and normalize-space(text())='(öffnet im neuen Fenster)']
 
 


### PR DESCRIPTION
The 2-year-old version wasn't suitable anymore, this update adapts it to the current site layout.