### PR TITLE
golem.de: extract main article

### DIFF
--- a/golem.de.txt
+++ b/golem.de.txt
@@ -15,6 +15,7 @@ date: //time
 author: //a[@rel='author']
 
 # Content is here
+body: //main/article
 body: //article
 
 # Fetch full multipage articles

--- a/golem.de.txt
+++ b/golem.de.txt
@@ -37,6 +37,7 @@ strip_id_or_class: footer
 strip_id_or_class: job-market
 strip_id_or_class: tags
 strip_id_or_class: topictags
+strip_id_or_class: go-button-bar
 strip: //div[contains(@class, 'authors--withsource')]
 strip: //div[@class='toc']
 strip: //li[not(.//text()[normalize-space()])][not(@class)]

--- a/golem.de.txt
+++ b/golem.de.txt
@@ -63,6 +63,7 @@ strip: //figure/figcaption[contains(text(), 'Bitte aktivieren Sie Javascript')]
 # Tidy up links
 strip_attr: //a/@title
 strip_attr: //a/@target
+strip: //svg[contains(@class, 'go-external-link__icon')]
 strip: //span[@class='go-vh' and normalize-space(text())='(öffnet im neuen Fenster)']
 
 


### PR DESCRIPTION
The previous `//article` selector was overly broad, as there can be more than 10 `<article>` elements on each page, with only the first element being the actual main article. Most of the others are related reading.

This defines the main article as `//main/article`, with fallback to `//article` just in case.

This also strips the SVG icon added to each external hyperlink.