### PR TITLE
Fix body extraction for https://danluu.com

### DIFF
--- a/danluu.com.txt
+++ b/danluu.com.txt
@@ -1,4 +1,4 @@
-body: //html
+body: /html/body/main
 
 prune: no
 


### PR DESCRIPTION
I noticed empty body when using one tools that makes use of these rules (https://codeberg.org/readeck/readeck).  The following XPath fixed it.