### PR TITLE
Update berliner-zeitung.de.txt

### DIFF
--- a/berliner-zeitung.de.txt
+++ b/berliner-zeitung.de.txt
@@ -1,6 +1,19 @@
-body: //main[@id='main']//article
+title: //h1[@id='article-title']
+body: //main//article
+author: //a[contains(@href,'/autoren/')]/span
+date: //time[@datetime]/@datetime
 
-strip: //div[contains(@class, 'article_articleHeaderSocialWrapper__')]
-strip: //div[contains(@class, 'soft-paywall_wrapper__')]
+strip: //article//article
+strip: //div[starts-with(@id,'qmn-ad-')]
+strip: //div[@id='article-share']
+strip: //div[@id='beyondwords-player-root']
+strip: //div[@id='beyondwords-custom-ui']
+strip: //div[@id='copy-link-popup']
+strip: //div[@id='paywall-tabs']
+strip: //button[@id='paywall-login-button']
+strip: //button[@data-paywall-submit]
+strip: //div[@id='endOfContent']
+strip_id_or_class: blz-sidebar
+strip_id_or_class: paywall
 
 test_url: https://www.berliner-zeitung.de/wirtschaft-verantwortung/militarisierung-in-adlershof-so-bereiten-chemiker-die-bundeswehr-auf-krieg-vor-li.2361153


### PR DESCRIPTION
The site config for berliner-zeitung.de was largely outdated - the old class-based strip rules no longer matched the site's current HTML, and the body selector failed due to a missing `id="main"` attribute on `<main>`. This PR rewrites the config from scratch: fixes the body selector to `//main//article`, adds explicit XPath selectors for title, author, and date, strips nested article teasers, and replaces the stale class-based strip rules with targeted ID-based rules covering ads, share buttons, audio players, paywall UI, and sidebar elements.