### PR TITLE
feat: add Centre France newspapers configurations

### DIFF
--- a/lamontagne.fr.txt
+++ b/lamontagne.fr.txt
@@ -1,0 +1,9 @@
+title: //div[@id="content"]//h1[@class="typo-h1"]
+body: //div[@id="content"]//section[@class="article"]
+
+strip_id_or_class: aspect-video
+strip_id_or_class: print:hidden
+
+test_url: https://www.lamontagne.fr/moulins-03000/actualites/150-personnes-a-moulins-pour-soutenir-le-journal-l-humanite-face-a-mumures-de-la-cite-devant-le-tribunal_14979990/
+test_url: https://www.lamontagne.fr/moulins-03000/actualites/l-udaf-de-l-allier-met-en-place-une-bulle-d-r-pour-les-aidants-des-personnes-en-situation-de-handicap_14974670/
+test_url: https://www.lamontagne.fr/moulins-03000/economie/la-guinguette-des-champins-a-moulins-est-de-retour_14977659/

--- a/larep.fr.txt
+++ b/larep.fr.txt
@@ -1,0 +1,9 @@
+title: //div[@id="content"]//h1[@class="typo-h1"]
+body: //div[@id="content"]//section[@class="article"]
+
+strip_id_or_class: aspect-video
+strip_id_or_class: print:hidden
+
+test_url: https://www.lamontagne.fr/moulins-03000/actualites/150-personnes-a-moulins-pour-soutenir-le-journal-l-humanite-face-a-mumures-de-la-cite-devant-le-tribunal_14979990/
+test_url: https://www.lamontagne.fr/moulins-03000/actualites/l-udaf-de-l-allier-met-en-place-une-bulle-d-r-pour-les-aidants-des-personnes-en-situation-de-handicap_14974670/
+test_url: https://www.lamontagne.fr/moulins-03000/economie/la-guinguette-des-champins-a-moulins-est-de-retour_14977659/

--- a/le-pays.fr.txt
+++ b/le-pays.fr.txt
@@ -1,0 +1,9 @@
+title: //div[@id="content"]//h1[@class="typo-h1"]
+body: //div[@id="content"]//section[@class="article"]
+
+strip_id_or_class: aspect-video
+strip_id_or_class: print:hidden
+
+test_url: https://www.lamontagne.fr/moulins-03000/actualites/150-personnes-a-moulins-pour-soutenir-le-journal-l-humanite-face-a-mumures-de-la-cite-devant-le-tribunal_14979990/
+test_url: https://www.lamontagne.fr/moulins-03000/actualites/l-udaf-de-l-allier-met-en-place-une-bulle-d-r-pour-les-aidants-des-personnes-en-situation-de-handicap_14974670/
+test_url: https://www.lamontagne.fr/moulins-03000/economie/la-guinguette-des-champins-a-moulins-est-de-retour_14977659/

--- a/leberry.fr.txt
+++ b/leberry.fr.txt
@@ -1,0 +1,9 @@
+title: //div[@id="content"]//h1[@class="typo-h1"]
+body: //div[@id="content"]//section[@class="article"]
+
+strip_id_or_class: aspect-video
+strip_id_or_class: print:hidden
+
+test_url: https://www.lamontagne.fr/moulins-03000/actualites/150-personnes-a-moulins-pour-soutenir-le-journal-l-humanite-face-a-mumures-de-la-cite-devant-le-tribunal_14979990/
+test_url: https://www.lamontagne.fr/moulins-03000/actualites/l-udaf-de-l-allier-met-en-place-une-bulle-d-r-pour-les-aidants-des-personnes-en-situation-de-handicap_14974670/
+test_url: https://www.lamontagne.fr/moulins-03000/economie/la-guinguette-des-champins-a-moulins-est-de-retour_14977659/

--- a/lechorepublicain.fr.txt
+++ b/lechorepublicain.fr.txt
@@ -1,0 +1,9 @@
+title: //div[@id="content"]//h1[@class="typo-h1"]
+body: //div[@id="content"]//section[@class="article"]
+
+strip_id_or_class: aspect-video
+strip_id_or_class: print:hidden
+
+test_url: https://www.lamontagne.fr/moulins-03000/actualites/150-personnes-a-moulins-pour-soutenir-le-journal-l-humanite-face-a-mumures-de-la-cite-devant-le-tribunal_14979990/
+test_url: https://www.lamontagne.fr/moulins-03000/actualites/l-udaf-de-l-allier-met-en-place-une-bulle-d-r-pour-les-aidants-des-personnes-en-situation-de-handicap_14974670/
+test_url: https://www.lamontagne.fr/moulins-03000/economie/la-guinguette-des-champins-a-moulins-est-de-retour_14977659/

--- a/lejdc.fr.txt
+++ b/lejdc.fr.txt
@@ -1,0 +1,9 @@
+title: //div[@id="content"]//h1[@class="typo-h1"]
+body: //div[@id="content"]//section[@class="article"]
+
+strip_id_or_class: aspect-video
+strip_id_or_class: print:hidden
+
+test_url: https://www.lamontagne.fr/moulins-03000/actualites/150-personnes-a-moulins-pour-soutenir-le-journal-l-humanite-face-a-mumures-de-la-cite-devant-le-tribunal_14979990/
+test_url: https://www.lamontagne.fr/moulins-03000/actualites/l-udaf-de-l-allier-met-en-place-une-bulle-d-r-pour-les-aidants-des-personnes-en-situation-de-handicap_14974670/
+test_url: https://www.lamontagne.fr/moulins-03000/economie/la-guinguette-des-champins-a-moulins-est-de-retour_14977659/

--- a/lepopulaire.fr.txt
+++ b/lepopulaire.fr.txt
@@ -1,0 +1,9 @@
+title: //div[@id="content"]//h1[@class="typo-h1"]
+body: //div[@id="content"]//section[@class="article"]
+
+strip_id_or_class: aspect-video
+strip_id_or_class: print:hidden
+
+test_url: https://www.lamontagne.fr/moulins-03000/actualites/150-personnes-a-moulins-pour-soutenir-le-journal-l-humanite-face-a-mumures-de-la-cite-devant-le-tribunal_14979990/
+test_url: https://www.lamontagne.fr/moulins-03000/actualites/l-udaf-de-l-allier-met-en-place-une-bulle-d-r-pour-les-aidants-des-personnes-en-situation-de-handicap_14974670/
+test_url: https://www.lamontagne.fr/moulins-03000/economie/la-guinguette-des-champins-a-moulins-est-de-retour_14977659/

--- a/leveil.fr.txt
+++ b/leveil.fr.txt
@@ -1,0 +1,9 @@
+title: //div[@id="content"]//h1[@class="typo-h1"]
+body: //div[@id="content"]//section[@class="article"]
+
+strip_id_or_class: aspect-video
+strip_id_or_class: print:hidden
+
+test_url: https://www.lamontagne.fr/moulins-03000/actualites/150-personnes-a-moulins-pour-soutenir-le-journal-l-humanite-face-a-mumures-de-la-cite-devant-le-tribunal_14979990/
+test_url: https://www.lamontagne.fr/moulins-03000/actualites/l-udaf-de-l-allier-met-en-place-une-bulle-d-r-pour-les-aidants-des-personnes-en-situation-de-handicap_14974670/
+test_url: https://www.lamontagne.fr/moulins-03000/economie/la-guinguette-des-champins-a-moulins-est-de-retour_14977659/

--- a/lyonne.fr.txt
+++ b/lyonne.fr.txt
@@ -1,0 +1,9 @@
+title: //div[@id="content"]//h1[@class="typo-h1"]
+body: //div[@id="content"]//section[@class="article"]
+
+strip_id_or_class: aspect-video
+strip_id_or_class: print:hidden
+
+test_url: https://www.lamontagne.fr/moulins-03000/actualites/150-personnes-a-moulins-pour-soutenir-le-journal-l-humanite-face-a-mumures-de-la-cite-devant-le-tribunal_14979990/
+test_url: https://www.lamontagne.fr/moulins-03000/actualites/l-udaf-de-l-allier-met-en-place-une-bulle-d-r-pour-les-aidants-des-personnes-en-situation-de-handicap_14974670/
+test_url: https://www.lamontagne.fr/moulins-03000/economie/la-guinguette-des-champins-a-moulins-est-de-retour_14977659/


### PR DESCRIPTION
Add specific configuration for lamontagne.fr, lepopulaire.fr, larep.fr, leberry.fr, lyonne.fr, lechorepublicain.fr, lejdc.fr, leveil.fr and le-pays.fr.