### PR TITLE
Fix perspective-daily.de pixelated preview thumbnails

### DIFF
--- a/perspective-daily.de.txt
+++ b/perspective-daily.de.txt
@@ -5,6 +5,10 @@ strip: //cite
 
 skip_json_ld: yes
 
+# LQIP blur placeholders in img src break wallabag list previews (pixelated thumbnails)
+find_string: blur:100/q:1/
+replace_string: q:85/
+
 requires_login: yes
 not_logged_in_xpath: //form[@id='signupForm']
 
@@ -15,3 +19,4 @@ login_password_field: password
 login_extra_fields: csrfmiddlewaretoken=@=xpath('//input[@name="csrfmiddlewaretoken"]', request_html('https://perspective-daily.de/enrol/login'))
 
 test_url: https://perspective-daily.de/article/1212
+test_url: https://perspective-daily.de/article/4741-wie-dieser-mann-den-reichen-und-maechtigen-einfluesterte-das-wahre-problem-hiesse-demokratie/cdazHLS6


### PR DESCRIPTION
## Summary

perspective-daily.de uses LQIP blur placeholder URLs in article `img` tags (`blur:100/q:1/w:…`). Wallabag often uses the first in-content image for list preview thumbnails, which appears heavily pixelated when upscaled.

This adds a `find_string` / `replace_string` pair to convert blur placeholders to normal Bunny CDN quality URLs (`q:85/`).

## Test plan

- [ ] Fetch test URL and verify in-content `img` src values no longer contain `blur:100`
- [ ] Preview/thumbnail image is sharp in wallabag article list
- [ ] Existing login-related site config rules unchanged

test_url: https://perspective-daily.de/article/4741-wie-dieser-mann-den-reichen-und-maechtigen-einfluesterte-das-wahre-problem-hiesse-demokratie/cdazHLS6

Made with [Cursor](https://cursor.com)