### PR TITLE
Add/fix site configs for republik, forum-geldpolitik, wendezeit, krautreporter

### DIFF
--- a/forum-geldpolitik.ch.txt
+++ b/forum-geldpolitik.ch.txt
@@ -1,0 +1,31 @@
+# forum-geldpolitik.ch (Squarespace)
+#
+# Hero image in blog-item-banner uses lazy-loaded data-src (no src). og:image uses http.
+# Use a single blog-wrapper body xpath — separate body: lines stop at the first match
+# (banner-only yields hero image but zero article text).
+
+http_header(user-agent): Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36
+
+find_string: property="og:image"
+replace_string: property="og:image-ignored"
+
+find_string: data-src="https://
+replace_string: src="https://
+
+title: substring-before(//meta[@property="og:title"]/@content, ' — Forum Geldpolitik')
+title: //h1[contains(@class,'entry-title')]
+
+body: //div[contains(@class,'blog-wrapper')]
+
+strip: //footer[contains(@class,'blog-item-footer')]
+strip: //div[contains(@class,'blog-item-actions')]
+strip: //div[contains(@class,'blog-item-author-profile')]
+strip: //section[contains(@class,'blog-item-pagination')]
+strip: //aside[contains(@class,'blog-item-sidebar')]
+strip: //section[contains(@class,'blog-item-comments')]
+
+autodetect_on_failure: no
+prune: no
+tidy: no
+
+test_url: https://forum-geldpolitik.ch/themen/2026/39-wertspeicher

--- a/krautreporter.de.txt
+++ b/krautreporter.de.txt
@@ -1,6 +1,31 @@
-body: //div[contains(concat(' ',normalize-space(@class),' '),' article-content ')]
-replace_string(<img src=): <img notused=
-replace_string(ix-path='): src='https://krautreporter.imgix.net
+# krautreporter.de
+#
+# Old config targeted removed .article-content and disabled imgs via
+# replace_string(<img src=): <img notused=. og:image is a cropped social variant;
+# ignore it so wallabag uses the hero image from the article header.
 
-test_url: https://krautreporter.de/2244-stell-dir-vor-du-erbst-nazi-geld-was-machst-du?shared=c30432e7-4d96-42c5-85d3-354e1f90482d
+http_header(user-agent): Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36
 
+find_string: property="og:image"
+replace_string: property="og:image-ignored"
+
+title: //meta[@property="og:title"]/@content
+title: //h1[contains(@class,'article-headers-standard__title')]
+
+body: //article[contains(@class,'article-article__main')]
+
+strip: //section[contains(@class,'article-share-url')]
+strip: //div[contains(@class,'article-tabbed-content__tab-row')]
+strip: //section[contains(@class,'article-headers-shared-metrics')]
+strip: //section[contains(@class,'article-tabbed-content__author')]
+strip: //article[contains(@class,'article-tabbed-content__listening-content')]
+strip: //article[contains(@class,'article-audio-player-component')]
+strip: //nav[contains(@class,'article-table-of-contents')]
+strip: //svg
+strip: //button
+
+autodetect_on_failure: no
+prune: no
+tidy: no
+
+test_url: https://krautreporter.de/politik-und-macht/6268-7-schritte-wie-du-die-perfekte-verschworungserzahlung-erfindest

--- a/republik.ch.txt
+++ b/republik.ch.txt
@@ -1,0 +1,30 @@
+# republik.ch — Next.js articles with hero illustration in <figure>, text in .regwall
+#
+# og:image points to a different asset than the illustration in <figure>. Wallabag
+# uses og:image for list previews, so a generic/social image appeared instead of the
+# article illustration. Ignore og:image so wallabag uses the first in-content <img>.
+
+http_header(user-agent): Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36
+
+find_string: property="og:image"
+replace_string: property="og:image-ignored"
+
+title: //meta[@property="og:title"]/@content
+title: //article//h1
+
+body: //article
+
+strip: //article//div[@data-can-breakout='true' and contains(@class,'center') and not(ancestor::div[contains(@class,'regwall')])]
+strip: //button
+strip: //svg
+strip: //hr
+strip: //a[@title='Teilen' or @title='Lesezeichen hinzufügen']
+
+strip_attr: //img/@srcSet
+strip_attr: //img/@srcset
+
+autodetect_on_failure: no
+prune: no
+tidy: no
+
+test_url: https://www.republik.ch/2026/06/03/zeit-die-dinge-persoenlich-zu-nehmen

--- a/wendezeit.ch.txt
+++ b/wendezeit.ch.txt
@@ -1,0 +1,29 @@
+# wendezeit.ch (WordPress Neve + Rank Math)
+#
+# Sidebar widgets (book promo, search, TOC) sit beside the article. og:image carries
+# the featured image (not always in body). Do not strip picture/source — it removes imgs.
+
+http_header(user-agent): Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36
+
+title: //h1[contains(@class,'entry-title')]
+title: //meta[@property="og:title"]/@content
+
+body: //article[contains(@class,'nv-single-post-wrap')]
+
+strip: //div[contains(@class,'yarpp')]
+strip: //div[contains(@class,'entry-header')]
+strip: //aside
+strip: //div[contains(@id,'block-')]
+strip: //img[contains(@src,'Buch-1x1-Bewusstsein-Sidebar')]
+strip: //img[contains(@src,'UTD-Logo')]
+strip: //img[contains(@src,'Weltkugel')]
+strip: //img[contains(@src,'gravatar.com')]
+
+strip_attr: //img/@srcset
+strip_attr: //img/@sizes
+
+autodetect_on_failure: no
+prune: no
+tidy: no
+
+test_url: https://wendezeit.ch/eigenverantwortung-oder-gesellschaftliche-regeln/


### PR DESCRIPTION
## Summary
- Add `republik.ch.txt` — ignore wrong og:image, extract article with hero illustration
- Add `forum-geldpolitik.ch.txt` — Squarespace lazy images, single blog-wrapper body xpath
- Add `wendezeit.ch.txt` — WordPress Neve/Rank Math, sidebar strip, keep og:image for featured preview
- Update `krautreporter.de.txt` — replace broken img-disabling config and outdated body selector

## Test plan
- [ ] republik.ch article: illustration in preview and body
- [ ] forum-geldpolitik.ch article: hero image + full text (not title-only)
- [ ] wendezeit.ch article: featured preview, no sidebar book image
- [ ] krautreporter.de article: hero image, no generic preview