### PR TITLE
Add site config for pv-magazine.de

### DIFF
--- a/pv-magazine.de.txt
+++ b/pv-magazine.de.txt
@@ -1,0 +1,8 @@
+# pv-magazine.de — Cloudflare blocks Graby's default User-Agent (Chrome 15).
+# Modern UA restores fetch; Readability handles free articles.
+# Premium posts (_premium) remain teaser-only without shop SSO cookies.
+
+http_header(user-agent): Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36
+
+test_url: https://www.pv-magazine.de/2026/06/23/montel-hitzewelle-sorgt-fuer-rekord-strompreise-in-europa/
+test_contains: historischen Preisspitzen


### PR DESCRIPTION
pv-magazine.de sits behind Cloudflare. Graby's default User-Agent (Chrome 15) triggers a challenge and the fetch fails.

This config sets a modern browser User-Agent only. Readability then extracts free articles without extra selectors.

Note: premium articles (`_premium` URLs) stay teaser-only without shop SSO cookies — server-side paywall, not a fetch issue.

## Test

- `test_url` points at a representative free article (June 2026).
- `test_contains` checks a phrase from the article body.
- Verified saving a free article in Wallabag with this config.

Fixes failed fetches for the German pv magazine site in Wallabag/graby.