### PR TITLE
Add site config for cato.org

### DIFF
--- a/cato.org.txt
+++ b/cato.org.txt
@@ -1,10 +1,17 @@
-# Site config for Cato Institute (cato.org)
-# Test URL: https://www.cato.org/blog/immigrants-use-less-welfare-even-counting-their-us-born-children
+# Site uses JavaScript, API-calls and/or techniques to prevent content catching, so...
 
-# Extract title, date, author
+# This works NOT with ftr.fivefilters.net (FTR|Fulltext-RSS)
+# This works NOT with wallabag UI
+
+# This only works with wallabagger browser-plugin with activated
+# option 'Retrieve content from the browser' in it's settings
+##############################################
+
+# Extract title, date, author (will not work with wallabagger)
 title: //h1[@property='headline']
 date: //meta[@property='article:published_time']/@content
 author: //span[@property='author']
+author: //div[contains(@class, 'authors')]//a
 
 # Extract body
 body: //div[contains(concat(' ', normalize-space(@class), ' '), ' js-read-depth-tracking-container ')]

--- a/cato.org.txt
+++ b/cato.org.txt
@@ -1,0 +1,16 @@
+# Site config for Cato Institute (cato.org)
+# Test URL: https://www.cato.org/blog/immigrants-use-less-welfare-even-counting-their-us-born-children
+
+# Extract title, date, author
+title: //h1[@property='headline']
+date: //meta[@property='article:published_time']/@content
+author: //span[@property='author']
+
+# Extract body
+body: //div[contains(concat(' ', normalize-space(@class), ' '), ' js-read-depth-tracking-container ')]
+body: //div[contains(concat(' ', normalize-space(@class), ' '), ' main-content ')]
+
+# Strip elements we don't need
+strip: //div[contains(concat(' ', normalize-space(@class), ' '), ' sentinel ')]
+
+test_url: https://www.cato.org/blog/immigrants-use-less-welfare-even-counting-their-us-born-children


### PR DESCRIPTION
Cato Institute articles are wrapped in Drupal-specific layout containers that the default parser heuristics struggle to isolate cleanly, often pulling in adjacent sidebar links or footer elements.

This configuration defines specific selectors to target the core article:
- **Title**: Extracted from the `headline` property element (`//h1[@property='headline']`).
- **Date**: Fetched from the OpenGraph published time metadata (`//meta[@property='article:published_time']/@content`).
- **Author**: Extracted from the `author` property span (`//span[@property='author']`).
- **Body**: Targets the main content area (`.main-content` / `.js-read-  depth-tracking-container`) to ensure the article body is fully extracted.
- **Cleanup**: Strips the layout's internal read-depth tracking elements (`.sentinel`) to deliver clean, markup-free output.
