### PR TITLE
Update scraping rules for stadt-bremerhaven.de

### DIFF
--- a/stadt-bremerhaven.de.txt
+++ b/stadt-bremerhaven.de.txt
@@ -10,6 +10,9 @@ strip: //div[@class='aawp']
 strip_id_or_class: aawp-disclaimer
 strip_id_or_class: su-posts
 strip_id_or_class: wp-embedded-content
+strip: //div[contains(@class,'cb-bookmark-container')]
+strip: //div[contains(@class,'cb-error-report-wrap')]
+strip: //a[contains(@class,'cb-internal-link-card')]
 
 # remove google preferences box
 strip: //a[contains(@href, 'google.com/preferences/')]

--- a/stadt-bremerhaven.de.txt
+++ b/stadt-bremerhaven.de.txt
@@ -10,9 +10,9 @@ strip: //div[@class='aawp']
 strip_id_or_class: aawp-disclaimer
 strip_id_or_class: su-posts
 strip_id_or_class: wp-embedded-content
-strip: //div[contains(@class,'cb-bookmark-container')]
-strip: //div[contains(@class,'cb-error-report-wrap')]
-strip: //a[contains(@class,'cb-internal-link-card')]
+strip_id_or_class: cb-bookmark-container
+strip_id_or_class: cb-error-report-wrap
+strip_id_or_class: cb-internal-link-card
 
 # remove google preferences box
 strip: //a[contains(@href, 'google.com/preferences/')]


### PR DESCRIPTION
The site recently added post widgets that now end up in extracted full text:

- a bookmark / copy-link bar at the end of each article ("Beitrag merken", "Link kopieren")
- an error-report link ("Fehler im Artikel entdeckt? Hier melden.")
- inline cards linking to other articles (title, excerpt, "Jetzt lesen →")

These elements are rendered inside the article content, so they appear as noise in full-text feeds.

This adds strip rules for the corresponding containers:

- `div.cb-bookmark-container` – bookmark / copy-link bar
- `div.cb-error-report-wrap` – error-report link
- `a.cb-internal-link-card` – inline related-article cards (the anchor wraps the whole card)

Verified against live articles, e.g. https://stadt-bremerhaven.de/huk-e-barometer-rekord-bei-umstiegen-auf-e-autos-im-privaten-bereich/