### PR TITLE
Ny2

### DIFF
--- a/newyorker.com.txt
+++ b/newyorker.com.txt
@@ -15,10 +15,8 @@ strip: //h1
 strip: //div[@data-testid="BylinesWrapper"]
 strip: //time
 strip: //ul[@data-testid="socialIconslist"]
-strip: //div[contains(concat(' ', normalize-space(@class), ' '), ' caption ')]
 
 # Clean up body
-strip: //div[@data-testid="GenericCallout"]
 strip: //figure[@data-testid="IframeEmbed"]
 
 # Strip unrelated cartoons

--- a/newyorker.com.txt
+++ b/newyorker.com.txt
@@ -29,7 +29,7 @@ tidy: no
 http_header(Cookie): pay_ent_msmp=1
 
 test_url: https://www.newyorker.com/magazine/2016/02/08/mothers-day-fiction-george-saunders
-test_url: https://www.newyorker.com/online/blogs/culture/2012/06/mug-shot-web-sites.html
+test_url: https://www.newyorker.com/culture/culture-desk/hotties-hunks-beat-up-celebrities-the-allure-of-the-mug-shot
 test_url: https://www.newyorker.com/reporting/2013/04/22/130422fa_fact_bilger?currentPage=all&mobify=0
 test_url: https://www.newyorker.com/magazine/2023/11/20/a-coder-considers-the-waning-days-of-the-craft
 # Cartoons

--- a/newyorker.com.txt
+++ b/newyorker.com.txt
@@ -1,11 +1,4 @@
-# Emphasize lead paragraph (replace needs to be done before parsing body)
-find_string: <header
-replace_string: <em
-find_string: </header>
-replace_string: </em>
-
-body: //em[@data-testid='SplitScreenContentHeaderWrapper'] | //div[@class='body__inner-container']
-
+body: //header[@data-testid='SplitScreenContentHeaderWrapper'] | //div[@class='body__inner-container']
 author: //meta[@property="article:author"]/@content
 
 date: //meta[@property="article:published_time"]/@content


### PR DESCRIPTION
@digicommons 
- needed to remove your stringreplacement of header node because this caused pushtokindle to set whole article into italic font style. Doesn't help to also string_replace the closing nodes.
- removed a strip which prevents in-article images to show up, e.g. https://www.newyorker.com/culture/postscript/dolly-parton-for-the-people
- removed strip of image captions as they sometimes have useful information
- fixed one test_url