### PR TITLE
Fix titles in d12frosted

### DIFF
--- a/d12frosted.io.txt
+++ b/d12frosted.io.txt
@@ -5,6 +5,13 @@ body: //main//article//div[@id="post-content"]
 # [wallabag] activate images
 strip_attr: //img[contains(@src, '/')]/@srcset
 
+# Strip the "#1" in front of titles. This solution is clean and works
+# everywhere except in Wallabag:
+strip_id_or_class: heading-level-indicator
+# This solution is less clean but works in Wallabag:
+find_string: text-ink-muted">#1
+replace_string: text-ink-muted">
+
 prune: no
 tidy: no
 


### PR DESCRIPTION
The source HTML looks like this:

``` html
  <h1 class="relative">
    <span class="heading-level-indicator absolute …">#1</span>
    A schema, in one breath
  </h1>
```


This commit gets rid of the "#1" prefix in each title. I first tried
to add the following to the config:

``` yaml
strip_id_or_class: heading-level-indicator
```

but it never worked. Apparently, there is a process transforming the
above `<h1>` before the `strip_id_or_class` is applied so the latter
never finds anything to strip.